### PR TITLE
Load global config in caclmgrd only in multi asic NPU

### DIFF
--- a/src/sonic-host-services/scripts/caclmgrd
+++ b/src/sonic-host-services/scripts/caclmgrd
@@ -101,7 +101,9 @@ class ControlPlaneAclManager(daemon_base.DaemonBase):
         self.lock[DEFAULT_NAMESPACE] = threading.Lock()
         self.num_changes[DEFAULT_NAMESPACE] = 0
 
-        swsscommon.SonicDBConfig.load_sonic_global_db_config()
+        if device_info.is_multi_npu():
+            swsscommon.SonicDBConfig.load_sonic_global_db_config()
+
         self.config_db_map = {}
         self.iptables_cmd_ns_prefix = {}
         self.config_db_map[DEFAULT_NAMESPACE] = swsscommon.ConfigDBConnector(use_unix_socket_path=True, namespace=DEFAULT_NAMESPACE)


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
The database_global.json file is generated only in multi asic scenario. However, caclmgrd calls initialization based on this file without multi npu check.
This leads to following error in single asic scenario
Sep 21 22:35:20.996798 r-leopard-32 ERR caclmgrd[11819]: :- initializeGlobalConfig: Sonic database config global file doesn't exist at /var/run/redis/sonic-db/database_global.json

#### How I did it
Added if multi npu check before invoking the load global config.

#### How to verify it
Restart caclmgrd after this change and check if no error log is thrown.

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


#### A picture of a cute animal (not mandatory but encouraged)

