### PR TITLE
Handle feature flow when state is always_enabled

### DIFF
--- a/src/sonic-host-services/scripts/hostcfgd
+++ b/src/sonic-host-services/scripts/hostcfgd
@@ -180,6 +180,7 @@ class FeatureHandler(object):
             disable = feature.state in ("always_disabled", "disabled")
         elif cached_feature.state in ("always_enabled", "always_disabled"):
             disable = feature.state == "always_disabled"
+            enable = feature.state == "always_enabled"
         elif cached_feature.state in ("enabled", "disabled"):
             enable = feature.state == "enabled"
             disable = feature.state == "disabled"

--- a/src/sonic-host-services/tests/hostcfgd/test_vectors.py
+++ b/src/sonic-host-services/tests/hostcfgd/test_vectors.py
@@ -146,6 +146,15 @@ HOSTCFGD_TEST_VECTOR = [
                         "state": "enabled",
                         "status": "enabled"
                     },
+                    "sflow": {
+                        "auto_restart": "enabled",
+                        "has_global_scope": "True",
+                        "has_per_asic_scope": "False",
+                        "has_timer": "False",
+                        "high_mem_alert": "disabled",
+                        "set_owner": "local",
+                        "state": "always_enabled"
+                    },
                 },
             },
             "expected_config_db": {
@@ -178,6 +187,15 @@ HOSTCFGD_TEST_VECTOR = [
                         "state": "enabled",
                         "status": "enabled"
                     },
+                    "sflow": {
+                        "auto_restart": "enabled",
+                        "has_global_scope": "True",
+                        "has_per_asic_scope": "False",
+                        "has_timer": "False",
+                        "high_mem_alert": "disabled",
+                        "set_owner": "local",
+                        "state": "always_enabled"
+                    },
                 },
             },
             "expected_subprocess_calls": [
@@ -188,6 +206,9 @@ HOSTCFGD_TEST_VECTOR = [
                 call("sudo systemctl unmask telemetry.timer", shell=True),
                 call("sudo systemctl enable telemetry.timer", shell=True),
                 call("sudo systemctl start telemetry.timer", shell=True),
+                call("sudo systemctl unmask sflow.service", shell=True),
+                call("sudo systemctl enable sflow.service", shell=True),
+                call("sudo systemctl start sflow.service", shell=True),
             ],
             "popen_attributes": {
                 'communicate.return_value': ('output', 'error')


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
When feature state is set to always_enabled hostcfgd throws error message
Sep 21 22:30:55.135377 r-leopard-32 ERR /hostcfgd: Unexpected state value 'always_enabled' for feature bgp
Sep 21 22:30:55.420268 r-leopard-32 ERR /hostcfgd: Unexpected state value 'always_enabled' for feature database
Sep 21 22:30:58.672714 r-leopard-32 ERR /hostcfgd: Unexpected state value 'always_enabled' for feature swss
This is due to feature == always_enabled not handled properly.

#### How I did it
Handled the scenario when feature is always enabled

#### How to verify it
Restart hostcfgd with feature state configured as always_enabled and check if there are no errors.

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


#### A picture of a cute animal (not mandatory but encouraged)

