### PR TITLE
[DPB][Mellanox]Fixing breakout modes in Mellanox-SN2700-D40C8S8

### DIFF
--- a/device/mellanox/x86_64-mlnx_msn2700-r0/Mellanox-SN2700-D40C8S8/hwsku.json
+++ b/device/mellanox/x86_64-mlnx_msn2700-r0/Mellanox-SN2700-D40C8S8/hwsku.json
@@ -12,9 +12,6 @@
         "Ethernet3": {
             "default_brkout_mode": "4x10G[25G]"
         }, 
-        "Ethernet4": {
-            "default_brkout_mode": "1x100G[50G,40G,25G,10G]"
-        }, 
         "Ethernet8": {
             "default_brkout_mode": "4x10G[25G]"
         }, 
@@ -26,9 +23,6 @@
         }, 
         "Ethernet11": {
             "default_brkout_mode": "4x10G[25G]"
-        }, 
-        "Ethernet12": {
-            "default_brkout_mode": "1x100G[50G,40G,25G,10G]"
         }, 
         "Ethernet16": {
             "default_brkout_mode": "2x50G[25G,10G]"


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Modified the port breakout combination for SN2700-D40C8S8. When Port 1 and Port 3 are in 4x mode port 2 and port 4 need to be disabled due to hardware limitation.

#### How I did it
Modifying hwsku.json

#### How to verify it
Load the new hw-sku.json

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


#### A picture of a cute animal (not mandatory but encouraged)

