### PR TITLE
[containerd]Fixing container commands when mode is local and state is disabled

### DIFF
--- a/src/sonic-ctrmgrd/ctrmgr/container
+++ b/src/sonic-ctrmgrd/ctrmgr/container
@@ -317,15 +317,13 @@ def container_kill(feature, **kwargs):
     docker_id = container_id(feature)
     remove_label = (set_owner != "local") or (current_owner != "local")
 
-    print("{}: set_owner:{} current_owner:{} remote_state:{} docker_id:{} state:{}".format(
+    debug_msg("{}: set_owner:{} current_owner:{} remote_state:{} docker_id:{} state:{}".format(
         feature, set_owner, current_owner, remote_state, docker_id, state))
 
-    print(remove_label)
     if remove_label:
         set_label(feature, False)
 
     if set_owner == "local":
-        print("returning failure")
         if state not in ["enabled", "always_enabled"]:
             debug_msg("{} is not enabled".format(feature))
             return FAILURE

--- a/src/sonic-ctrmgrd/ctrmgr/container
+++ b/src/sonic-ctrmgrd/ctrmgr/container
@@ -249,21 +249,16 @@ def container_stop(feature, **kwargs):
 
     init()
     ret = SUCCESS
-    set_owner, _ , state = read_config(feature)
+    set_owner, _ , _ = read_config(feature)
     current_owner, remote_state, _ = read_state(feature)
     docker_id = container_id(feature)
     remove_label = (remote_state != "pending") or (set_owner == "local")
 
-    debug_msg("{}: set_owner:{} current_owner:{} remote_state:{} docker_id:{} state:{}".format(
-        feature, set_owner, current_owner, remote_state, docker_id, state))
+    debug_msg("{}: set_owner:{} current_owner:{} remote_state:{} docker_id:{}".format(
+        feature, set_owner, current_owner, remote_state, docker_id))
 
     if remove_label:
         set_label(feature, False)
-
-    if set_owner == "local":
-        if state not in ["enabled", "always_enabled"]:
-            debug_msg("{} is not enabled".format(feature))
-            return FAILURE
 
     if docker_id:
         ret = docker_action("stop", docker_id, **kwargs)

--- a/src/sonic-ctrmgrd/ctrmgr/container
+++ b/src/sonic-ctrmgrd/ctrmgr/container
@@ -26,6 +26,7 @@ CONTAINER_ID = "container_id"
 REMOTE_STATE = "remote_state"
 VERSION = "container_version"
 SYSTEM_STATE = "system_state"
+STATE = "state"
 
 KUBE_LABEL_TABLE = "KUBE_LABELS"
 KUBE_LABEL_SET_KEY = "SET"
@@ -37,6 +38,9 @@ SONIC_CTR_CONFIG = "/etc/sonic/remote_ctr.config.json"
 SONIC_CTR_CONFIG_PEND_SECS = "revert_to_local_on_wait_seconds"
 DEFAULT_PEND_SECS = ( 5 * 60 )
 WAIT_POLL_SECS = 2
+
+SUCCESS = 0
+FAILURE = -1
 
 remote_ctr_enabled = False
 
@@ -87,10 +91,10 @@ def read_data(is_config, feature, fields):
 
 def read_config(feature):
     """ Read requried feature config """
-    set_owner, no_fallback  = read_data(True, feature, 
-            [(SET_OWNER, "local"), (NO_FALLBACK, False)])
+    set_owner, no_fallback, state  = read_data(True, feature, 
+            [(SET_OWNER, "local"), (NO_FALLBACK, False), (STATE, "disabled")])
 
-    return (set_owner, not no_fallback)
+    return (set_owner, not no_fallback, state)
 
 
 def read_state(feature):
@@ -107,12 +111,12 @@ def docker_action(action, feature, **kwargs):
         container = client.containers.get(feature)
         getattr(container, action)(**kwargs)
         syslog.syslog(syslog.LOG_INFO, "docker cmd: {} for {}".format(action, feature))
-        return 0
+        return SUCCESS
 
     except (docker.errors.NotFound, docker.errors.APIError) as err:
         syslog.syslog(syslog.LOG_ERR, "docker cmd: {} for {} failed with {}".
                 format(action, feature, str(err)))
-        return -1
+        return FAILURE
 
 
 def set_label(feature, create):
@@ -186,7 +190,7 @@ def container_start(feature, **kwargs):
 
     init()
 
-    set_owner, fallback = read_config(feature)
+    set_owner, fallback, _ = read_config(feature)
     _, remote_state, _ = read_state(feature)
 
     debug_msg("{}: set_owner:{} fallback:{} remote_state:{}".format(
@@ -244,20 +248,25 @@ def container_stop(feature, **kwargs):
     debug_msg("BEGIN")
 
     init()
-
-    set_owner, _ = read_config(feature)
+    ret = SUCCESS
+    set_owner, _ , state = read_config(feature)
     current_owner, remote_state, _ = read_state(feature)
     docker_id = container_id(feature)
     remove_label = (remote_state != "pending") or (set_owner == "local")
 
-    debug_msg("{}: set_owner:{} current_owner:{} remote_state:{} docker_id:{}".format(
-        feature, set_owner, current_owner, remote_state, docker_id))
+    debug_msg("{}: set_owner:{} current_owner:{} remote_state:{} docker_id:{} state:{}".format(
+        feature, set_owner, current_owner, remote_state, docker_id, state))
 
     if remove_label:
         set_label(feature, False)
 
+    if set_owner == "local":
+        if state not in ["enabled", "always_enabled"]:
+            debug_msg("{} is not enabled".format(feature))
+            return FAILURE
+
     if docker_id:
-        docker_action("stop", docker_id, **kwargs)
+        ret = docker_action("stop", docker_id, **kwargs)
     else:
         syslog.syslog(
                 syslog.LOG_ERR if current_owner != "none" else syslog.LOG_INFO,
@@ -286,6 +295,7 @@ def container_stop(feature, **kwargs):
     update_data(feature, data)
 
     debug_msg("END")
+    return ret
 
 
 def container_kill(feature, **kwargs):
@@ -301,19 +311,27 @@ def container_kill(feature, **kwargs):
 
     init()
 
-    set_owner, _ = read_config(feature)
+    ret = SUCCESS
+    set_owner, _ , state = read_config(feature)
     current_owner, remote_state, _ = read_state(feature)
     docker_id = container_id(feature)
     remove_label = (set_owner != "local") or (current_owner != "local")
 
-    debug_msg("{}: set_owner:{} current_owner:{} remote_state:{} docker_id:{}".format(
-        feature, set_owner, current_owner, remote_state, docker_id))
+    print("{}: set_owner:{} current_owner:{} remote_state:{} docker_id:{} state:{}".format(
+        feature, set_owner, current_owner, remote_state, docker_id, state))
 
+    print(remove_label)
     if remove_label:
         set_label(feature, False)
 
+    if set_owner == "local":
+        print("returning failure")
+        if state not in ["enabled", "always_enabled"]:
+            debug_msg("{} is not enabled".format(feature))
+            return FAILURE
+
     if docker_id:
-        docker_action("kill", docker_id, **kwargs)
+        ret = docker_action("kill", docker_id, **kwargs)
 
     else:
         syslog.syslog(
@@ -322,6 +340,7 @@ def container_kill(feature, **kwargs):
 
 
     debug_msg("END")
+    return ret
 
 
 def container_wait(feature, **kwargs):
@@ -341,10 +360,11 @@ def container_wait(feature, **kwargs):
 
     init()
 
-    set_owner, fallback = read_config(feature)
+    set_owner, fallback, _ = read_config(feature)
     current_owner, remote_state, _ = read_state(feature)
     docker_id = container_id(feature)
     pend_wait_secs = 0
+    ret = SUCCESS
 
     if not docker_id and fallback:
         pend_wait_secs = get_config_data(
@@ -377,8 +397,9 @@ def container_wait(feature, **kwargs):
                 format(feature))
     else:
         debug_msg("END -- transitioning to docker wait")
-        docker_action("wait", docker_id, **kwargs)
+        ret = docker_action("wait", docker_id, **kwargs)
 
+    return ret
 
 def main():
     parser=argparse.ArgumentParser(description="container commands for start/stop/wait/kill/id")
@@ -389,24 +410,26 @@ def main():
     args = parser.parse_args()
     kwargs = {}
 
+    ret = 0
     if args.action == "start":
-        container_start(args.name, **kwargs)
+        ret = container_start(args.name, **kwargs)
 
     elif args.action == "stop":
         if args.timeout is not None:
             kwargs['timeout'] = args.timeout
-        container_stop(args.name, **kwargs)
+        ret = container_stop(args.name, **kwargs)
 
     elif args.action == "kill":
-        container_kill(args.name, **kwargs)
+        ret = container_kill(args.name, **kwargs)
 
     elif args.action == "wait":
-        container_wait(args.name, **kwargs)
+        ret = container_wait(args.name, **kwargs)
 
     elif args.action == "id":
         id = container_id(args.name, **kwargs)
         print(id)
 
+    return ret
 
 if __name__ == "__main__":
     main()

--- a/src/sonic-ctrmgrd/tests/container_test.py
+++ b/src/sonic-ctrmgrd/tests/container_test.py
@@ -169,8 +169,7 @@ stop_test_data = {
             common_test.CONFIG_DB_NO: {
                 common_test.FEATURE_TABLE: {
                     "snmp": {
-                        "set_owner": "local",
-                        "state": "enabled"
+                        "set_owner": "local"
                     }
                 }
             },
@@ -254,28 +253,6 @@ stop_test_data = {
     }
 }
 
-
-# container_stop test cases
-# test case 0 -- container stop local for disabled container
-#
-invalid_stop_test_data = {
-    0: {
-        common_test.DESCR: "container stop for local disabled container",
-        common_test.PRE: {
-            common_test.CONFIG_DB_NO: {
-                common_test.FEATURE_TABLE: {
-                    "sflow": {
-                        "set_owner": "local"
-                    }
-                }
-            }
-        },
-        common_test.POST: {
-        },
-        common_test.ACTIONS: {
-        }
-    }
-}
 
 # container_kill test cases
 # test case 0 -- container kill local 
@@ -527,25 +504,6 @@ class TestContainer(object):
             ret = common_test.check_mock_containers()
             assert ret == 0
 
-
-    @patch("container.swsscommon.DBConnector")
-    @patch("container.swsscommon.Table")
-    @patch("container.docker.from_env")
-    def test_invalid_stop_ct(self, mock_docker, mock_table, mock_conn):
-        self.init()
-        common_test.set_mock(mock_table, mock_conn, mock_docker)
-
-        for (i, ct_data) in invalid_stop_test_data.items():
-            common_test.do_start_test("container_test:container_stop", i, ct_data)
-
-            ret = container.container_stop("sflow")
-            assert ret != 0
-
-            ret = common_test.check_tables_returned()
-            assert ret == 0
-
-            ret = common_test.check_mock_containers()
-            assert ret == 0
 
     @patch("container.swsscommon.DBConnector")
     @patch("container.swsscommon.Table")

--- a/src/sonic-ctrmgrd/tests/container_test.py
+++ b/src/sonic-ctrmgrd/tests/container_test.py
@@ -169,7 +169,8 @@ stop_test_data = {
             common_test.CONFIG_DB_NO: {
                 common_test.FEATURE_TABLE: {
                     "snmp": {
-                        "set_owner": "local"
+                        "set_owner": "local",
+                        "state": "enabled"
                     }
                 }
             },
@@ -254,6 +255,28 @@ stop_test_data = {
 }
 
 
+# container_stop test cases
+# test case 0 -- container stop local for disabled container
+#
+invalid_stop_test_data = {
+    0: {
+        common_test.DESCR: "container stop for local disabled container",
+        common_test.PRE: {
+            common_test.CONFIG_DB_NO: {
+                common_test.FEATURE_TABLE: {
+                    "sflow": {
+                        "set_owner": "local"
+                    }
+                }
+            }
+        },
+        common_test.POST: {
+        },
+        common_test.ACTIONS: {
+        }
+    }
+}
+
 # container_kill test cases
 # test case 0 -- container kill local 
 #   -- no change in state-db 
@@ -269,7 +292,8 @@ kill_test_data = {
             common_test.CONFIG_DB_NO: {
                 common_test.FEATURE_TABLE: {
                     "snmp": {
-                        "set_owner": "local"
+                        "set_owner": "local",
+                        "state": "enabled"
                     }
                 }
             },
@@ -344,6 +368,30 @@ kill_test_data = {
         },
         common_test.ACTIONS: {
             "xxx": [ "kill" ]
+        }
+    }
+}
+
+# container_kill test cases
+# test case 0 -- container kill local disabled container
+#   -- no change in state-db 
+#   -- no label update
+#
+invalid_kill_test_data = {
+    0: {
+        common_test.DESCR: "container kill for local disabled container",
+        common_test.PRE: {
+            common_test.CONFIG_DB_NO: {
+                common_test.FEATURE_TABLE: {
+                    "sflow": {
+                        "set_owner": "local"
+                    }
+                }
+            }
+        },
+        common_test.POST: {
+        },
+        common_test.ACTIONS: {
         }
     }
 }
@@ -483,6 +531,25 @@ class TestContainer(object):
     @patch("container.swsscommon.DBConnector")
     @patch("container.swsscommon.Table")
     @patch("container.docker.from_env")
+    def test_invalid_stop_ct(self, mock_docker, mock_table, mock_conn):
+        self.init()
+        common_test.set_mock(mock_table, mock_conn, mock_docker)
+
+        for (i, ct_data) in invalid_stop_test_data.items():
+            common_test.do_start_test("container_test:container_stop", i, ct_data)
+
+            ret = container.container_stop("sflow")
+            assert ret != 0
+
+            ret = common_test.check_tables_returned()
+            assert ret == 0
+
+            ret = common_test.check_mock_containers()
+            assert ret == 0
+
+    @patch("container.swsscommon.DBConnector")
+    @patch("container.swsscommon.Table")
+    @patch("container.docker.from_env")
     def test_kill(self, mock_docker, mock_table, mock_conn):
         self.init()
         common_test.set_mock(mock_table, mock_conn, mock_docker)
@@ -498,6 +565,24 @@ class TestContainer(object):
             ret = common_test.check_mock_containers()
             assert ret == 0
 
+    @patch("container.swsscommon.DBConnector")
+    @patch("container.swsscommon.Table")
+    @patch("container.docker.from_env")
+    def test_invalid_kill(self, mock_docker, mock_table, mock_conn):
+        self.init()
+        common_test.set_mock(mock_table, mock_conn, mock_docker)
+
+        for (i, ct_data) in invalid_kill_test_data.items():
+            common_test.do_start_test("container_test:container_kill", i, ct_data)
+
+            ret = container.container_kill("sflow")
+
+            assert ret != 0
+            ret = common_test.check_tables_returned()
+            assert ret == 0
+
+            ret = common_test.check_mock_containers()
+            assert ret == 0
 
     @patch("container.swsscommon.DBConnector")
     @patch("container.swsscommon.Table")


### PR DESCRIPTION
Signed-off-by: Sudharsan Dhamal Gopalarathnam <sudharsand@nvidia.com>

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
During warm-reboot and fast-reboot the below error logs appear
Feb  3 22:05:15.187408 r-lionfish-13 ERR container: docker cmd: kill for nat failed with 404 Client Error for http+docker://localhost/v1.41/containers/nat/json: Not Found ("No such container: nat")

The container command when called for local mode doesn't check if it is enabled before calling docker kill which throws the above errors. 
https://github.com/Azure/sonic-utilities/blob/b6ca76b4821453171d9607383b808385968eeeeb/scripts/fast-reboot#L699

#### How I did it
Checking feature state if local mode and returning error exit code along with valid debug message.

#### How to verify it
Added UT to verify it.

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


#### A picture of a cute animal (not mandatory but encouraged)

