### PR TITLE
[BGP]Adding configuration knob to allow advertise Loopback ipv6 /128 prefix

### DIFF
--- a/dockers/docker-fpm-frr/frr/bgpd/bgpd.main.conf.j2
+++ b/dockers/docker-fpm-frr/frr/bgpd/bgpd.main.conf.j2
@@ -11,7 +11,11 @@
 ip prefix-list PL_LoopbackV4 permit {{ get_ipv4_loopback_address(LOOPBACK_INTERFACE, "Loopback0") | ip }}/32
 !
 {% if get_ipv6_loopback_address(LOOPBACK_INTERFACE, "Loopback0") != 'None' %}
+{% if DEVICE_METADATA['localhost']['bgp_adv_lo_prefix_as_128'] == 'true' %}
+ipv6 prefix-list PL_LoopbackV6 permit {{ get_ipv6_loopback_address(LOOPBACK_INTERFACE, "Loopback0") | ip_network }}/128
+{% else %}
 ipv6 prefix-list PL_LoopbackV6 permit {{ get_ipv6_loopback_address(LOOPBACK_INTERFACE, "Loopback0") | replace('/128', '/64') | ip_network }}/64
+{% endif %}
 {% endif %}
 !
 {% if VLAN_INTERFACE is defined %}
@@ -89,7 +93,11 @@ router bgp {{ DEVICE_METADATA['localhost']['bgp_asn'] }}
 !
 {% if get_ipv6_loopback_address(LOOPBACK_INTERFACE, "Loopback0") != 'None' %}
   address-family ipv6
+{% if DEVICE_METADATA['localhost']['bgp_adv_lo_prefix_as_128'] == 'true' %}
+    network {{ get_ipv6_loopback_address(LOOPBACK_INTERFACE, "Loopback0") | ip }}/128
+{% else %}
     network {{ get_ipv6_loopback_address(LOOPBACK_INTERFACE, "Loopback0") | ip }}/64
+{% endif %}
   exit-address-family
 {% endif %}
 {% if ((multi_asic is defined and DEVICE_METADATA['localhost']['switch_type'] != 'chassis-packet') or (DEVICE_METADATA['localhost']['switch_type'] == 'voq')) %}

--- a/dockers/docker-fpm-frr/frr/staticd/staticd.loopback_route.conf.j2
+++ b/dockers/docker-fpm-frr/frr/staticd/staticd.loopback_route.conf.j2
@@ -2,9 +2,14 @@
 {% from "common/functions.conf.j2" import get_ipv4_loopback_address, get_ipv6_loopback_address, get_vnet_interfaces %}
 !
 {% block loopback_route %}
-! add static ipv6 /64 loopback route to allow bgpd to advertise the loopback route prefix
 {% if get_ipv6_loopback_address(LOOPBACK_INTERFACE, "Loopback0") != 'None' %}
+{% if DEVICE_METADATA['localhost']['bgp_adv_lo_prefix_as_128'] == 'true' %}
+! add static ipv6 /128 loopback route to allow bgpd to advertise the loopback route prefix
+ipv6 route {{ get_ipv6_loopback_address(LOOPBACK_INTERFACE, "Loopback0") | ip_network }}/128 Loopback0
+{% else %}
+! add static ipv6 /64 loopback route to allow bgpd to advertise the loopback route prefix
 ipv6 route {{ get_ipv6_loopback_address(LOOPBACK_INTERFACE, "Loopback0") | replace('/128', '/64') | ip_network }}/64 Loopback0
+{% endif %}
 {% endif %}
 {% endblock loopback_route %}
 !

--- a/src/sonic-bgpcfgd/tests/data/sonic-cfggen/bgpd.main.conf.j2/ipv6_lo.conf
+++ b/src/sonic-bgpcfgd/tests/data/sonic-cfggen/bgpd.main.conf.j2/ipv6_lo.conf
@@ -1,0 +1,27 @@
+!
+! template: bgpd/bgpd.main.conf.j2
+!
+! bgp multiple-instance
+!
+! BGP configuration
+!
+! TSA configuration
+!
+ip prefix-list PL_LoopbackV4 permit 55.55.55.55/32
+!
+ipv6 prefix-list PL_LoopbackV6 permit fc00::1/128
+!
+router bgp 55555
+!
+  bgp log-neighbor-changes
+  no bgp default ipv4-unicast
+  no bgp ebgp-requires-policy
+!
+  bgp router-id 55.55.55.55
+!
+  network 55.55.55.55/32
+!
+  address-family ipv6
+    network fc00::1/128
+! end of template: bgpd/bgpd.main.conf.j2
+!

--- a/src/sonic-bgpcfgd/tests/data/sonic-cfggen/bgpd.main.conf.j2/ipv6_lo.json
+++ b/src/sonic-bgpcfgd/tests/data/sonic-cfggen/bgpd.main.conf.j2/ipv6_lo.json
@@ -1,0 +1,18 @@
+{
+    "DEVICE_METADATA": {
+        "localhost": {
+            "bgp_asn": "55555",
+            "bgp_adv_lo_prefix_as_128": "true"
+        }
+    },
+    "LOOPBACK_INTERFACE": {
+        "Loopback0|fc00::1/128": {}
+    },
+    "constants": {
+        "bgp": {
+            "multipath_relax": {},
+            "graceful_restart": {},
+            "maximum_paths": {}
+        }
+    }
+}

--- a/src/sonic-bgpcfgd/tests/data/sonic-cfggen/staticd/staticd.loopback_ipv6_128_route.conf
+++ b/src/sonic-bgpcfgd/tests/data/sonic-cfggen/staticd/staticd.loopback_ipv6_128_route.conf
@@ -1,0 +1,4 @@
+!
+! add static ipv6 /128 loopback route to allow bgpd to advertise the loopback route prefix
+ipv6 route fc00:1::32/128 Loopback0
+!!

--- a/src/sonic-bgpcfgd/tests/data/sonic-cfggen/staticd/staticd.loopback_ipv6_128_route.conf.json
+++ b/src/sonic-bgpcfgd/tests/data/sonic-cfggen/staticd/staticd.loopback_ipv6_128_route.conf.json
@@ -1,6 +1,7 @@
 {
     "DEVICE_METADATA": {
         "localhost": {
+            "bgp_adv_lo_prefix_as_128": "true"
         }
     },
     "LOOPBACK_INTERFACE": {

--- a/src/sonic-bgpcfgd/tests/test_sonic-cfggen.py
+++ b/src/sonic-bgpcfgd/tests/test_sonic-cfggen.py
@@ -57,6 +57,12 @@ def test_bgpd_main_conf_packet_chassis():
              "bgpd.main.conf.j2/packet_chassis.json",
              "bgpd.main.conf.j2/packet_chassis.conf")
 
+def test_bgpd_lo_ipv6_conf_base():
+    run_test("IPv6 Loopback bgpd.main.conf.j2",
+             "bgpd/bgpd.main.conf.j2",
+             "bgpd.main.conf.j2/base.json",
+             "bgpd.main.conf.j2/base.conf")
+
 def test_tsa_isolate():
     run_test("tsa/bgpd.tsa.isolate.conf.j2",
              "bgpd/tsa/bgpd.tsa.isolate.conf.j2",
@@ -86,6 +92,12 @@ def test_staticd_loopback_route():
              "staticd/staticd.loopback_route.conf.j2",
              "staticd/staticd.loopback_route.conf.json",
              "staticd/staticd.loopback_route.conf")
+
+def test_staticd_loopback_ipv6_128_route():
+    run_test("staticd.loopback_ipv6_128_route.conf.j2",
+             "staticd/staticd.loopback_route.conf.j2",
+             "staticd/staticd.loopback_ipv6_128_route.conf.json",
+             "staticd/staticd.loopback_ipv6_128_route.conf")
 
 def test_staticd():
     run_test("staticd.conf.j2",

--- a/src/sonic-yang-models/doc/Configuration.md
+++ b/src/sonic-yang-models/doc/Configuration.md
@@ -773,6 +773,7 @@ instance is supported in SONiC.
         "bgp_asn": "65100",
         "deployment_id": "1",
         "type": "ToRRouter",
+        "bgp_adv_lo_prefix_as_128" : "true",
         "buffer_model": "traditional"
     }
   }
@@ -933,6 +934,9 @@ Loopback interface configuration lies in **LOOPBACK_INTERFACE** table
 and has similar schema with data plane interfaces. The loopback device
 name and loopback IP prefix act as multi-level key for loopback
 interface objects.
+By default SONiC advertises Loopback interface IPv6 /128 subnet address
+as prefix with /64 subnet. To overcome this set "bgp_adv_lo_prefix_as_128"
+to true in DEVICE_METADATA
 
 ```
 {

--- a/src/sonic-yang-models/tests/files/sample_config_db.json
+++ b/src/sonic-yang-models/tests/files/sample_config_db.json
@@ -319,7 +319,8 @@
                 "switch_type": "voq",
                 "max_cores": "8",
                 "sub_role": "FrontEnd",
-                "dhcp_server": "disabled"
+                "dhcp_server": "disabled",
+                "bgp_adv_lo_prefix_as_128": "true"
             }
         },
         "VLAN": {

--- a/src/sonic-yang-models/tests/yang_model_tests/tests/device_metadata.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests/device_metadata.json
@@ -113,6 +113,9 @@
     "DEVICE_METADATA_INVALID_DHCP_SERVER": {
         "desc": "Verifying invalid dhcp_server configuration.",
         "eStrKey": "InvalidValue"
+    },
+    "DEVICE_METADATA_ADVERTISE_LO_PREFIX_AS_128": {
+        "desc": "Verifying advertising lo prefix as /128."
     }
 
 }

--- a/src/sonic-yang-models/tests/yang_model_tests/tests_config/device_metadata.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests_config/device_metadata.json
@@ -311,5 +311,15 @@
                 }
             }
         }
+    },
+    "DEVICE_METADATA_ADVERTISE_LO_PREFIX_AS_128": {
+        "sonic-device_metadata:sonic-device_metadata": {
+            "sonic-device_metadata:DEVICE_METADATA": {
+                "sonic-device_metadata:localhost": {
+                    "bgp_asn": "65001",
+                    "bgp_adv_lo_prefix_as_128": "true"
+                }
+            }
+        }
     }
 }

--- a/src/sonic-yang-models/yang-models/sonic-device_metadata.yang
+++ b/src/sonic-yang-models/yang-models/sonic-device_metadata.yang
@@ -188,6 +188,12 @@ module sonic-device_metadata {
                     type stypes:admin_mode;
                     description "Indicate whether enable the embedded DHCP server.";
                 }
+
+                leaf bgp_adv_lo_prefix_as_128 {
+                    type boolean;
+                    description "Advertise Loopback0 interface IPv6 /128 subnet address as it is with set to true.
+                                 By default SONiC advertises /128 subnet prefix in Loopback0 as /64 subnet route";
+                }
             }
             /* end of container localhost */
         }


### PR DESCRIPTION

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
By default when IPv6 address is configured with /128 as subnet mask in Loopback0 interface, it will be advertised as prefix with /64 subnet.
To control this behavior a new field 'bgp_adv_lo_prefix_as_128' is introduced in DEVICE_METADATA table which when set to true will advertise prefix with /128 subnet as it is.

#### How I did it
Modified the jinja templates and yang model to parse this field and advertise route as /128

#### How to verify it
Added UT in sonic-cfggen test as well yang to verify it

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

