### PR TITLE
[Mellanox]Check dmi file permission before access in platform API

### DIFF
--- a/platform/mellanox/mlnx-platform-api/sonic_platform/chassis.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/chassis.py
@@ -649,6 +649,9 @@ class Chassis(ChassisBase):
         """
         result = {}
         try:
+            if not os.access(filename, os.R_OK):
+                return result
+
             with open(filename, "rb") as fileobj:
                 data = fileobj.read()
 

--- a/platform/mellanox/mlnx-platform-api/tests/test_chassis.py
+++ b/platform/mellanox/mlnx-platform-api/tests/test_chassis.py
@@ -269,3 +269,16 @@ class TestChassis:
         module_list = chassis.get_all_modules()
         assert len(module_list) == 3
         assert chassis.module_initialized_count == 3
+
+    def test_revision_permission(self):
+        old_dmi_file =  sonic_platform.chassis.DMI_FILE
+        #Override the dmi file
+        sonic_platform.chassis.DMI_FILE = "/tmp/dmi_file"
+        new_dmi_file = sonic_platform.chassis.DMI_FILE
+        os.system("touch " + new_dmi_file)
+        os.system("chmod -r " + new_dmi_file)
+        chassis = Chassis()
+        rev = chassis.get_revision()
+        sonic_platform.chassis.DMI_FILE = old_dmi_file
+        os.system("rm -f " + new_dmi_file)
+        assert rev == "N/A"


### PR DESCRIPTION
Signed-off-by: Sudharsan Dhamal Gopalarathnam <sudharsand@nvidia.com>

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
During the system boot up when 'show platform status' or 'show version' command is executed before STATE_DB CHASSIS_INFO table is populated, the show will try to fallback to use the platform API. The DMI file in mellanox platforms require root permission for access. So if the show commands are executed as admin or any other user, the following error log will appear in the syslog

Jun 28 17:21:25.612123 sonic ERR show: Fail to decode DMI /sys/firmware/dmi/entries/2-0/raw due to PermissionError(13, 'Permission denied')

#### How I did it
Check the file permission before accessing it.

#### How to verify it
Added UT to verify.

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [x] 202205

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

