### PR TITLE
[202012][mellanox]Fix lpmode set when logical port is larger than 64

### DIFF
--- a/device/mellanox/x86_64-mlnx_msn2700-r0/plugins/sfplpmset.py
+++ b/device/mellanox/x86_64-mlnx_msn2700-r0/plugins/sfplpmset.py
@@ -52,7 +52,7 @@ def set_port_admin_status_by_log_port(handle, log_port, admin_status):
 def get_log_ports(handle, sfp_module):
     port_cnt_p = new_uint32_t_p()
     uint32_t_p_assign(port_cnt_p, 0)
-    rc = sx_api_port_device_get(handle, 1, 0, None,  port_cnt_p)
+    rc = sx_api_port_device_get(handle, DEVICE_ID, SWITCH_ID, None,  port_cnt_p)
 
     assert rc == SX_STATUS_SUCCESS, "sx_api_port_device_get failed, rc = %d" % rc
     port_cnt = uint32_t_p_value(port_cnt_p)

--- a/device/mellanox/x86_64-mlnx_msn2700-r0/plugins/sfplpmset.py
+++ b/device/mellanox/x86_64-mlnx_msn2700-r0/plugins/sfplpmset.py
@@ -11,7 +11,6 @@ from python_sdk_api.sx_api import *
 
 DEVICE_ID = 1
 SWITCH_ID = 0
-SX_PORT_ATTR_ARR_SIZE = 64
 
 PORT_TYPE_CPU = 4
 PORT_TYPE_NVE = 8
@@ -51,9 +50,13 @@ def set_port_admin_status_by_log_port(handle, log_port, admin_status):
 
 
 def get_log_ports(handle, sfp_module):
-    port_attributes_list = new_sx_port_attributes_t_arr(SX_PORT_ATTR_ARR_SIZE)
     port_cnt_p = new_uint32_t_p()
-    uint32_t_p_assign(port_cnt_p, SX_PORT_ATTR_ARR_SIZE)
+    uint32_t_p_assign(port_cnt_p, 0)
+    rc = sx_api_port_device_get(handle, 1, 0, None,  port_cnt_p)
+
+    assert rc == SX_STATUS_SUCCESS, "sx_api_port_device_get failed, rc = %d" % rc
+    port_cnt = uint32_t_p_value(port_cnt_p)
+    port_attributes_list = new_sx_port_attributes_t_arr(port_cnt)
 
     rc = sx_api_port_device_get(handle, DEVICE_ID, SWITCH_ID, port_attributes_list,  port_cnt_p)
     assert rc == SX_STATUS_SUCCESS, "sx_api_port_device_get failed, rc = %d" % rc


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
In sfplpm API, the number of logical ports is hardcoded as 64. When a system contains more port than this, the SDK APIs would fail with a trace as below

Enabling low-power mode for port Ethernet0... Traceback (most recent call last):
  File "/usr/share/sonic/platform/plugins/sfplpmset.py", line 167, in <module>
    set_lpmode(handle, cmd, sfp_module)
  File "/usr/share/sonic/platform/plugins/sfplpmset.py", line 128, in set_lpmode
    SX_MGMT_PHY_MOD_PWR_ATTR_PWR_MODE_E, SX_MGMT_PHY_MOD_PWR_MODE_LOW_E)
  File "/usr/share/sonic/platform/plugins/sfplpmset.py", line 115, in pwr_attr_set
    mgmt_phy_mod_pwr_attr_set(handle, module_id, attr_type, power_mode)
  File "/usr/share/sonic/platform/plugins/sfplpmset.py", line 84, in mgmt_phy_mod_pwr_attr_set
    assert SX_STATUS_SUCCESS == rc, "sx_mgmt_phy_mod_pwr_attr_set failed"
AssertionError: sx_mgmt_phy_mod_pwr_attr_set failed
Error! Unable to set LPM for 1, rc = 1, err msg: [+] opening sdk
Mar 07 03:25:28 INFO    LOG: Initializing SX log with STDOUT as output file.
Mar 07 03:25:28 ERROR   SX_API_PORT: sx_mgmt_phy_mod_pwr_attr_get: This API is deprecated and will be removed in the future. Please use sx_mgmt_phy_module_pwr_attr_get in its place.
Mar 07 03:25:28 ERROR   SX_API_PORT: sx_mgmt_phy_mod_pwr_attr_set: This API is deprecated and will be removed in the future. Please use sx_mgmt_phy_module_pwr_attr_set in its place.

Failed

#### How I did it
Remove the hardcoded value of 64. Obtained the number of logical ports from SDK

#### How to verify it
Manual testing

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

