### PR TITLE
[FRR] Adding patches for CVE-2023-41360 and CVE-2023-41359

### DIFF
--- a/src/sonic-frr/patch/0022-bgpd-Don-t-read-the-first-byte-of-ORF-header-if-we-a.patch
+++ b/src/sonic-frr/patch/0022-bgpd-Don-t-read-the-first-byte-of-ORF-header-if-we-a.patch
@@ -1,0 +1,27 @@
+From 4fcb9d0764b14463f797f2819905ab819dd770f5 Mon Sep 17 00:00:00 2001
+From: Donatas Abraitis <donatas@opensourcerouting.org>
+Date: Sun, 20 Aug 2023 22:15:27 +0300
+Subject: [PATCH] bgpd: Don't read the first byte of ORF header if we are ahead
+ of stream
+
+Reported-by: Iggy Frankovic iggyfran@amazon.com
+Signed-off-by: Donatas Abraitis <donatas@opensourcerouting.org>
+(cherry picked from commit 9b855a692e68e0d16467e190b466b4ecb6853702)
+
+diff --git a/bgpd/bgp_packet.c b/bgpd/bgp_packet.c
+index a2959ef6e..60f1dcbcd 100644
+--- a/bgpd/bgp_packet.c
++++ b/bgpd/bgp_packet.c
+@@ -2408,7 +2408,8 @@ static int bgp_route_refresh_receive(struct peer *peer, bgp_size_t size)
+ 				 * and 7 bytes of ORF Address-filter entry from
+ 				 * the stream
+ 				 */
+-				if (*p_pnt & ORF_COMMON_PART_REMOVE_ALL) {
++				if (p_pnt < p_end &&
++				    *p_pnt & ORF_COMMON_PART_REMOVE_ALL) {
+ 					if (bgp_debug_neighbor_events(peer))
+ 						zlog_debug(
+ 							"%pBP rcvd Remove-All pfxlist ORF request",
+-- 
+2.17.1
+

--- a/src/sonic-frr/patch/0023-bgpd-Make-sure-we-have-enough-data-to-read-two-bytes.patch
+++ b/src/sonic-frr/patch/0023-bgpd-Make-sure-we-have-enough-data-to-read-two-bytes.patch
@@ -1,0 +1,51 @@
+From da62ad75f69f2e0e4ec51c7dd5e79bd810f636b6 Mon Sep 17 00:00:00 2001
+From: Donatas Abraitis <donatas@opensourcerouting.org>
+Date: Fri, 18 Aug 2023 11:28:03 +0300
+Subject: [PATCH] bgpd: Make sure we have enough data to read two bytes when
+ validating AIGP
+
+Found when fuzzing:
+
+```
+==3470861==ERROR: AddressSanitizer: heap-buffer-overflow on address 0xffff77801ef7 at pc 0xaaaaba7b3dbc bp 0xffffcff0e760 sp 0xffffcff0df50
+READ of size 2 at 0xffff77801ef7 thread T0
+    0 0xaaaaba7b3db8 in __asan_memcpy (/home/ubuntu/frr_8_5_2/frr_8_5_2_fuzz_clang/bgpd/bgpd+0x363db8) (BuildId: cc710a2356e31c7f4e4a17595b54de82145a6e21)
+    1 0xaaaaba81a8ac in ptr_get_be16 /home/ubuntu/frr_8_5_2/frr_8_5_2_fuzz_clang/./lib/stream.h:399:2
+    2 0xaaaaba819f2c in bgp_attr_aigp_valid /home/ubuntu/frr_8_5_2/frr_8_5_2_fuzz_clang/bgpd/bgp_attr.c:504:3
+    3 0xaaaaba808c20 in bgp_attr_aigp /home/ubuntu/frr_8_5_2/frr_8_5_2_fuzz_clang/bgpd/bgp_attr.c:3275:7
+    4 0xaaaaba7ff4e0 in bgp_attr_parse /home/ubuntu/frr_8_5_2/frr_8_5_2_fuzz_clang/bgpd/bgp_attr.c:3678:10
+```
+
+Reported-by: Iggy Frankovic <iggyfran@amazon.com>
+Signed-off-by: Donatas Abraitis <donatas@opensourcerouting.org>
+(cherry picked from commit f96201e104892e18493f24cf67bb713678e8237b)
+
+diff --git a/bgpd/bgp_attr.c b/bgpd/bgp_attr.c
+index 8e66a229c..2ef50ffe5 100644
+--- a/bgpd/bgp_attr.c
++++ b/bgpd/bgp_attr.c
+@@ -513,6 +513,7 @@ static bool bgp_attr_aigp_valid(uint8_t *pnt, int length)
+ 	uint8_t *data = pnt;
+ 	uint8_t tlv_type;
+ 	uint16_t tlv_length;
++	uint8_t *end = data + length;
+ 
+ 	if (length < 3) {
+ 		zlog_err("Bad AIGP attribute length (MUST be minimum 3): %u",
+@@ -521,7 +522,13 @@ static bool bgp_attr_aigp_valid(uint8_t *pnt, int length)
+ 	}
+ 
+ 	while (length) {
++		size_t data_len = end - data;
++
+ 		tlv_type = *data;
++
++		if (data_len - 1 < 2)
++			return false;
++
+ 		ptr_get_be16(data + 1, &tlv_length);
+ 		(void)data;
+ 
+-- 
+2.17.1
+

--- a/src/sonic-frr/patch/series
+++ b/src/sonic-frr/patch/series
@@ -21,3 +21,5 @@ cross-compile-changes.patch
 0019-zebra-Abstract-dplane_ctx_route_init-to-init-route-w.patch
 0020-zebra-Fix-crash-when-dplane_fpm_nl-fails-to-process-.patch
 0021-zebra-remove-duplicated-nexthops-when-sending-fpm-msg.patch
+0022-bgpd-Don-t-read-the-first-byte-of-ORF-header-if-we-a.patch
+0023-bgpd-Make-sure-we-have-enough-data-to-read-two-bytes.patch


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Created patches to address two CVEs from FRR CVE-2023-41359 and CVE-2023-41360

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
Porting fixes as patches from FRR.

#### How to verify it
Running regression.
<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

