### PR TITLE
[FRR]Fixing zebra to handle non notification of better admin won

### DIFF
--- a/src/sonic-frr/patch/0027-zebra-Fix-non-notification-of-better-admin-won.patch
+++ b/src/sonic-frr/patch/0027-zebra-Fix-non-notification-of-better-admin-won.patch
@@ -1,0 +1,61 @@
+From 4b7ca0f0063b7ddb85c0b6fb3ce6bfeaa26e460f Mon Sep 17 00:00:00 2001
+From: dgsudharsan <sudharsand@nvidia.com>
+Date: Tue, 14 Nov 2023 23:21:42 +0000
+Subject: [PATCH] zebra: Fix non-notification of better admin won If there
+ happens to be a entry in the zebra rib that has a lower admin distance then a
+ newly received re, zebra would not notify the upper level protocol about this
+ happening.  Imagine a case where there is a connected route for say a /32 and
+ bgp receives a route from a peer that is the same route as the connected. 
+ Since BGP has no network statement and perceives the route as being `good`
+ bgp will install the route into zebra.  Zebra will look at the new bgp re and
+ correctly identify that the re is not something that it will use and do
+ nothing.  This change notices this and sends up a BETTER_ADMIN_WON route
+ notification.
+
+
+diff --git a/zebra/zebra_rib.c b/zebra/zebra_rib.c
+index 039c44cc0..1c0da1df8 100644
+--- a/zebra/zebra_rib.c
++++ b/zebra/zebra_rib.c
+@@ -1209,6 +1209,7 @@ static void rib_process(struct route_node *rn)
+ 	rib_dest_t *dest;
+ 	struct zebra_vrf *zvrf = NULL;
+ 	struct vrf *vrf;
++	struct route_entry *proto_re_changed = NULL;
+ 
+ 	vrf_id_t vrf_id = VRF_UNKNOWN;
+ 
+@@ -1278,6 +1279,7 @@ static void rib_process(struct route_node *rn)
+ 		 * skip it.
+ 		 */
+ 		if (CHECK_FLAG(re->status, ROUTE_ENTRY_CHANGED)) {
++			proto_re_changed = re;
+ 			if (!nexthop_active_update(rn, re)) {
+ 				const struct prefix *p;
+ 				struct rib_table_info *info;
+@@ -1417,6 +1419,22 @@ static void rib_process(struct route_node *rn)
+ 		}
+ 	}
+ 
++	/*
++	 * If zebra has a new_selected and a proto_re_changed
++	 * entry that was not the old selected and the protocol
++	 * is different, zebra should notify the upper level
++	 * protocol that the sent down entry was not selected
++	 */
++	if (new_selected && proto_re_changed &&
++	    proto_re_changed != old_selected &&
++	    new_selected->type != proto_re_changed->type) {
++		struct rib_table_info *info = srcdest_rnode_table_info(rn);
++
++		zsend_route_notify_owner(rn, proto_re_changed,
++					 ZAPI_ROUTE_BETTER_ADMIN_WON, info->afi,
++					 info->safi);
++	}
++
+ 	/* Update fib according to selection results */
+ 	if (new_fib && old_fib)
+ 		rib_process_update_fib(zvrf, rn, old_fib, new_fib);
+-- 
+2.17.1
+

--- a/src/sonic-frr/patch/series
+++ b/src/sonic-frr/patch/series
@@ -26,3 +26,4 @@ cross-compile-changes.patch
 0024-bgpd-Do-not-process-NLRIs-if-the-attribute-length-is.patch
 0025-bgpd-Use-treat-as-withdraw-for-tunnel-encapsulation-.patch
 0026-zebra-Add-encap-type-when-building-packet-for-FPM.patch
+0027-zebra-Fix-non-notification-of-better-admin-won.patch


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Fixing zebra to handle network removal statement

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

