### PR TITLE
[System Ready]Handle template value for feature table state field

### DIFF
--- a/src/system-health/health_checker/sysmonitor.py
+++ b/src/system-health/health_checker/sysmonitor.py
@@ -10,8 +10,10 @@ from swsscommon import swsscommon
 from sonic_py_common.logger import Logger
 from . import utils
 from sonic_py_common.task_base import ProcessTaskBase
+from sonic_py_common import device_info
 from .config import Config
 import signal
+import jinja2
 
 SYSLOG_IDENTIFIER = "system#monitor"
 REDIS_TIMEOUT_MS = 0
@@ -159,6 +161,26 @@ class Sysmonitor(ProcessTaskBase):
         dir_list.sort()
         return dir_list
 
+    def get_render_value_for_field(self, configuration, device_config, expected_values):
+        """ Returns the target value by rendering the configuration as J2 template.
+
+        Args:
+            configuration (str): Table value from CONFIG_DB for given field
+            device_config (dict): DEVICE_METADATA section of CONFIG_DB and populated Device Running Metadata which is needed for rendering
+            expected_values (list): Expected set of values for given field
+        Returns:
+            (str): Target value for given key
+        """
+
+        if configuration is None:
+            return None
+
+        template = jinja2.Template(configuration)
+        target_value = template.render(device_config)
+        if target_value not in expected_values:
+            raise ValueError('Invalid value rendered for configuration {}: {}'.format(configuration, target_value))
+        return target_value
+
     def get_service_from_feature_table(self, dir_list):
         """Get service from CONFIG DB FEATURE table. During "config reload" command, filling FEATURE table
            is not an atomic operation, sonic-cfggen do it with two steps:
@@ -178,12 +200,17 @@ class Sysmonitor(ProcessTaskBase):
         while max_retry > 0:
             success = True
             feature_table = self.config_db.get_table("FEATURE")
+            device_config = {}
+            device_config['DEVICE_METADATA'] = self.config_db.get_table('DEVICE_METADATA')
+            device_config.update(device_info.get_device_runtime_metadata())
+            print(device_config)
             for srv, fields in feature_table.items():
                 if 'state' not in fields:
                     success = False
                     logger.log_warning("FEATURE table is not fully ready: {}, retrying".format(feature_table))
                     break
-                if fields["state"] not in ["disabled", "always_disabled"]:
+                state = self.get_render_value_for_field(fields["state"], device_config, ['enabled', 'disabled', 'always_enabled', 'always_disabled'])
+                if state not in ["disabled", "always_disabled"]:
                     srvext = srv + ".service"
                     if srvext not in dir_list:
                         dir_list.append(srvext)

--- a/src/system-health/health_checker/sysmonitor.py
+++ b/src/system-health/health_checker/sysmonitor.py
@@ -203,7 +203,6 @@ class Sysmonitor(ProcessTaskBase):
             device_config = {}
             device_config['DEVICE_METADATA'] = self.config_db.get_table('DEVICE_METADATA')
             device_config.update(device_info.get_device_runtime_metadata())
-            print(device_config)
             for srv, fields in feature_table.items():
                 if 'state' not in fields:
                     success = False


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
To fix the issue where system ready state is 'Not ready' while all expected services are ready. This is due to some FEATURE table entries have state value as template and thus in sysmonitor when the value is checked whether its not [disabled](https://github.com/sonic-net/sonic-buildimage/blob/2e1410c7b7975d3bc5fad19d07fa7958f65ad9c4/src/system-health/health_checker/sysmonitor.py#L186) , the feature is assumed to be enabled and to be started by systemd while the rendering would result in disabled resulting in systemd not starting the feature.

Sysmonitor dnsrvs_name will this have this feature and consider the system wrongly down.



##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
Handled dynamic rendering of the feature

#### How to verify it
Run UT. Run install of system and ensure system state is not down when all services are up.

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

