### PR TITLE
[FRR]Setting multipath size to 512 and disabling bgp-vnc for optimization

### DIFF
--- a/src/sonic-frr/patch/0054-Updating-rules-to-set-multipath-to-512-and-removing-.patch
+++ b/src/sonic-frr/patch/0054-Updating-rules-to-set-multipath-to-512-and-removing-.patch
@@ -1,0 +1,23 @@
+From ca51d39440db46e766a81987f407ef794d697876 Mon Sep 17 00:00:00 2001
+From: dgsudharsan <sudharsand@nvidia.com>
+Date: Fri, 8 Nov 2024 22:14:31 +0000
+Subject: [PATCH] Updating rules to set multipath to 512 and removing bgp vnc
+
+
+diff --git a/debian/rules b/debian/rules
+index aa13106fec..e280b6c45b 100755
+--- a/debian/rules
++++ b/debian/rules
+@@ -68,8 +68,7 @@ override_dh_auto_configure:
+ 		--disable-protobuf \
+ 		--disable-zeromq \
+ 		--enable-ospfapi \
+-		--enable-bgp-vnc \
+-		--enable-multipath=256 \
++		--enable-multipath=512 \
+ 		\
+ 		--enable-user=frr \
+ 		--enable-group=frr \
+-- 
+2.43.2
+

--- a/src/sonic-frr/patch/series
+++ b/src/sonic-frr/patch/series
@@ -53,3 +53,4 @@
 0053-bgpd-Set-md5-TCP-socket-option-for-outgoing-connections-on-listener.patch
 build-dplane-fpm-sonic-module.patch
 bgpd-lib-Include-SID-structure-in-seg6local-nexthop.patch
+0054-Updating-rules-to-set-multipath-to-512-and-removing-.patch


### PR DESCRIPTION
…tion

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Increased the max multipath to 512. In addition removed bgp-vnc as this feature is not used by SONiC . 

https://docs.frrouting.org/en/latest/vnc.html#vnc-and-vnc-gw

This feature adds overhead in general and removing this improves bgp convergence time for scale.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
Added a patch

#### How to verify it
Running some basic tests in scaled topology
<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

