### PR TITLE
[BGP]Increasing maximum-paths to 512

### DIFF
--- a/dockers/docker-fpm-frr/frr/bgpd/bgpd.spine_chassis_frontend_router.conf.j2
+++ b/dockers/docker-fpm-frr/frr/bgpd/bgpd.spine_chassis_frontend_router.conf.j2
@@ -49,7 +49,7 @@ router bgp {{ DEVICE_METADATA['localhost']['bgp_asn'] }} vrf {{ vnet_name }}
   address-family ipv4 unicast
     neighbor {{ neighbor_addr }} activate
     neighbor {{ neighbor_addr }} soft-reconfiguration inbound
-    maximum-paths 64
+    maximum-paths 512
   exit-address-family
 {%      endif %}
   address-family l2vpn evpn

--- a/files/image_config/constants/constants.yml
+++ b/files/image_config/constants/constants.yml
@@ -19,8 +19,8 @@ constants:
       enabled: true
     maximum_paths:
       enabled: true
-      ipv4: 64
-      ipv6: 64
+      ipv4: 512
+      ipv6: 512
     allow_list:
       enabled: true
       default_action: "permit"   # or "deny"

--- a/platform/vs/tests/bgp/files/gr_livelock/bgpd.conf
+++ b/platform/vs/tests/bgp/files/gr_livelock/bgpd.conf
@@ -6,10 +6,10 @@ router bgp 65501
   neighbor 10.0.0.1 remote-as 65502
   address-family ipv4
     neighbor 10.0.0.1 activate
-    maximum-paths 64
+    maximum-paths 512
   exit-address-family
   neighbor 10.0.0.3 remote-as 65503
   address-family ipv4
     neighbor 10.0.0.3 activate
-    maximum-paths 64
+    maximum-paths 512
   exit-address-family

--- a/platform/vs/tests/bgp/files/no_export/bgpd.conf
+++ b/platform/vs/tests/bgp/files/no_export/bgpd.conf
@@ -5,10 +5,10 @@ router bgp 65501
   neighbor 10.0.0.1 remote-as 65502
   address-family ipv4
     neighbor 10.0.0.1 activate
-    maximum-paths 64
+    maximum-paths 512
   exit-address-family
   neighbor 10.0.0.3 remote-as 65503
   address-family ipv4
     neighbor 10.0.0.3 activate
-    maximum-paths 64
+    maximum-paths 512
   exit-address-family

--- a/src/sonic-bgpcfgd/tests/data/sonic-cfggen/bgpd.spine_chassis_frontend_router.conf.j2/base.conf
+++ b/src/sonic-bgpcfgd/tests/data/sonic-cfggen/bgpd.spine_chassis_frontend_router.conf.j2/base.conf
@@ -13,7 +13,7 @@ router bgp 555 vrf First
   address-family ipv4 unicast
     neighbor 10.10.10.1 activate
     neighbor 10.10.10.1 soft-reconfiguration inbound
-    maximum-paths 64
+    maximum-paths 512
   exit-address-family
   address-family l2vpn evpn
     advertise ipv4 unicast
@@ -31,7 +31,7 @@ router bgp 555 vrf Second
   address-family ipv4 unicast
     neighbor 20.20.20.1 activate
     neighbor 20.20.20.1 soft-reconfiguration inbound
-    maximum-paths 64
+    maximum-paths 512
   exit-address-family
   address-family l2vpn evpn
     advertise ipv4 unicast

--- a/src/sonic-config-engine/tests/sample_output/py2/bgpd_frr.conf
+++ b/src/sonic-config-engine/tests/sample_output/py2/bgpd_frr.conf
@@ -67,10 +67,10 @@ router bgp 65100
 !
 !
   address-family ipv4
-    maximum-paths 64
+    maximum-paths 512
   exit-address-family
   address-family ipv6
-    maximum-paths 64
+    maximum-paths 512
   exit-address-family
 !
 ! end of template: bgpd/bgpd.main.conf.j2

--- a/src/sonic-config-engine/tests/sample_output/py2/bgpd_frr_backend_asic.conf
+++ b/src/sonic-config-engine/tests/sample_output/py2/bgpd_frr_backend_asic.conf
@@ -76,10 +76,10 @@ router bgp 65100
 !
 !
   address-family ipv4
-    maximum-paths 64
+    maximum-paths 512
   exit-address-family
   address-family ipv6
-    maximum-paths 64
+    maximum-paths 512
   exit-address-family
 !
 ! end of template: bgpd/bgpd.main.conf.j2

--- a/src/sonic-config-engine/tests/sample_output/py2/bgpd_frr_dualtor.conf
+++ b/src/sonic-config-engine/tests/sample_output/py2/bgpd_frr_dualtor.conf
@@ -68,10 +68,10 @@ router bgp 65100
 !
 !
   address-family ipv4
-    maximum-paths 64
+    maximum-paths 512
   exit-address-family
   address-family ipv6
-    maximum-paths 64
+    maximum-paths 512
   exit-address-family
 !
 ! end of template: bgpd/bgpd.main.conf.j2

--- a/src/sonic-config-engine/tests/sample_output/py2/bgpd_frr_frontend_asic.conf
+++ b/src/sonic-config-engine/tests/sample_output/py2/bgpd_frr_frontend_asic.conf
@@ -82,10 +82,10 @@ router bgp 65100
   exit-address-family
 !
   address-family ipv4
-    maximum-paths 64
+    maximum-paths 512
   exit-address-family
   address-family ipv6
-    maximum-paths 64
+    maximum-paths 512
   exit-address-family
 !
 ! end of template: bgpd/bgpd.main.conf.j2

--- a/src/sonic-config-engine/tests/sample_output/py2/bgpd_quagga.conf
+++ b/src/sonic-config-engine/tests/sample_output/py2/bgpd_quagga.conf
@@ -35,7 +35,7 @@ router bgp 65100
     neighbor 10.0.0.59 allowas-in 1
     neighbor 10.0.0.59 activate
     neighbor 10.0.0.59 soft-reconfiguration inbound
-    maximum-paths 64
+    maximum-paths 512
   exit-address-family
   neighbor 10.0.0.61 remote-as 64600
   neighbor 10.0.0.61 description ARISTA03T1
@@ -43,7 +43,7 @@ router bgp 65100
     neighbor 10.0.0.61 allowas-in 1
     neighbor 10.0.0.61 activate
     neighbor 10.0.0.61 soft-reconfiguration inbound
-    maximum-paths 64
+    maximum-paths 512
   exit-address-family
   neighbor 10.0.0.63 remote-as 64600
   neighbor 10.0.0.63 description ARISTA04T1
@@ -51,7 +51,7 @@ router bgp 65100
     neighbor 10.0.0.63 allowas-in 1
     neighbor 10.0.0.63 activate
     neighbor 10.0.0.63 soft-reconfiguration inbound
-    maximum-paths 64
+    maximum-paths 512
   exit-address-family
   neighbor fc00::7e remote-as 64600
   neighbor fc00::7e description ARISTA04T1
@@ -59,7 +59,7 @@ router bgp 65100
     neighbor fc00::7e allowas-in 1
     neighbor fc00::7e activate
     neighbor fc00::7e soft-reconfiguration inbound
-    maximum-paths 64
+    maximum-paths 512
   exit-address-family
   neighbor fc00::7a remote-as 64600
   neighbor fc00::7a description ARISTA03T1
@@ -67,7 +67,7 @@ router bgp 65100
     neighbor fc00::7a allowas-in 1
     neighbor fc00::7a activate
     neighbor fc00::7a soft-reconfiguration inbound
-    maximum-paths 64
+    maximum-paths 512
   exit-address-family
   neighbor 10.0.0.57 remote-as 64600
   neighbor 10.0.0.57 description ARISTA01T1
@@ -75,7 +75,7 @@ router bgp 65100
     neighbor 10.0.0.57 allowas-in 1
     neighbor 10.0.0.57 activate
     neighbor 10.0.0.57 soft-reconfiguration inbound
-    maximum-paths 64
+    maximum-paths 512
   exit-address-family
   neighbor fc00::76 remote-as 64600
   neighbor fc00::76 description ARISTA02T1
@@ -83,7 +83,7 @@ router bgp 65100
     neighbor fc00::76 allowas-in 1
     neighbor fc00::76 activate
     neighbor fc00::76 soft-reconfiguration inbound
-    maximum-paths 64
+    maximum-paths 512
   exit-address-family
   neighbor fc00::72 remote-as 64600
   neighbor fc00::72 description ARISTA01T1
@@ -91,10 +91,10 @@ router bgp 65100
     neighbor fc00::72 allowas-in 1
     neighbor fc00::72 activate
     neighbor fc00::72 soft-reconfiguration inbound
-    maximum-paths 64
+    maximum-paths 512
   exit-address-family
 !
-maximum-paths 64
+maximum-paths 512
 !
 route-map ISOLATE permit 10
 set as-path prepend 65100

--- a/src/sonic-config-engine/tests/sample_output/py2/frr.conf
+++ b/src/sonic-config-engine/tests/sample_output/py2/frr.conf
@@ -87,10 +87,10 @@ router bgp 65100
 !
 !
   address-family ipv4
-    maximum-paths 64
+    maximum-paths 512
   exit-address-family
   address-family ipv6
-    maximum-paths 64
+    maximum-paths 512
   exit-address-family
 !
 ! end of template: bgpd/bgpd.main.conf.j2

--- a/src/sonic-config-engine/tests/sample_output/py2/t2-chassis-fe-bgpd.conf
+++ b/src/sonic-config-engine/tests/sample_output/py2/t2-chassis-fe-bgpd.conf
@@ -35,7 +35,7 @@ router bgp 4000 vrf VnetFE
   address-family ipv4 unicast
     neighbor 192.168.0.1 activate
     neighbor 192.168.0.1 soft-reconfiguration inbound
-    maximum-paths 64
+    maximum-paths 512
   exit-address-family
   address-family l2vpn evpn
     advertise ipv4 unicast
@@ -74,10 +74,10 @@ router bgp 4000
 !
 !
   address-family ipv4
-    maximum-paths 64
+    maximum-paths 512
   exit-address-family
   address-family ipv6
-    maximum-paths 64
+    maximum-paths 512
   exit-address-family
 !
 ! end of template: bgpd/bgpd.main.conf.j2

--- a/src/sonic-config-engine/tests/sample_output/py3/bgpd_frr.conf
+++ b/src/sonic-config-engine/tests/sample_output/py3/bgpd_frr.conf
@@ -67,10 +67,10 @@ router bgp 65100
 !
 !
   address-family ipv4
-    maximum-paths 64
+    maximum-paths 512
   exit-address-family
   address-family ipv6
-    maximum-paths 64
+    maximum-paths 512
   exit-address-family
 !
 ! end of template: bgpd/bgpd.main.conf.j2

--- a/src/sonic-config-engine/tests/sample_output/py3/bgpd_frr_backend_asic.conf
+++ b/src/sonic-config-engine/tests/sample_output/py3/bgpd_frr_backend_asic.conf
@@ -76,10 +76,10 @@ router bgp 65100
 !
 !
   address-family ipv4
-    maximum-paths 64
+    maximum-paths 512
   exit-address-family
   address-family ipv6
-    maximum-paths 64
+    maximum-paths 512
   exit-address-family
 !
 ! end of template: bgpd/bgpd.main.conf.j2

--- a/src/sonic-config-engine/tests/sample_output/py3/bgpd_frr_dualtor.conf
+++ b/src/sonic-config-engine/tests/sample_output/py3/bgpd_frr_dualtor.conf
@@ -68,10 +68,10 @@ router bgp 65100
 !
 !
   address-family ipv4
-    maximum-paths 64
+    maximum-paths 512
   exit-address-family
   address-family ipv6
-    maximum-paths 64
+    maximum-paths 512
   exit-address-family
 !
 ! end of template: bgpd/bgpd.main.conf.j2

--- a/src/sonic-config-engine/tests/sample_output/py3/bgpd_frr_frontend_asic.conf
+++ b/src/sonic-config-engine/tests/sample_output/py3/bgpd_frr_frontend_asic.conf
@@ -82,10 +82,10 @@ router bgp 65100
   exit-address-family
 !
   address-family ipv4
-    maximum-paths 64
+    maximum-paths 512
   exit-address-family
   address-family ipv6
-    maximum-paths 64
+    maximum-paths 512
   exit-address-family
 !
 ! end of template: bgpd/bgpd.main.conf.j2

--- a/src/sonic-config-engine/tests/sample_output/py3/bgpd_quagga.conf
+++ b/src/sonic-config-engine/tests/sample_output/py3/bgpd_quagga.conf
@@ -35,7 +35,7 @@ router bgp 65100
     neighbor 10.0.0.57 allowas-in 1
     neighbor 10.0.0.57 activate
     neighbor 10.0.0.57 soft-reconfiguration inbound
-    maximum-paths 64
+    maximum-paths 512
   exit-address-family
   neighbor fc00::72 remote-as 64600
   neighbor fc00::72 description ARISTA01T1
@@ -43,7 +43,7 @@ router bgp 65100
     neighbor fc00::72 allowas-in 1
     neighbor fc00::72 activate
     neighbor fc00::72 soft-reconfiguration inbound
-    maximum-paths 64
+    maximum-paths 512
   exit-address-family
   neighbor 10.0.0.59 remote-as 64600
   neighbor 10.0.0.59 description ARISTA02T1
@@ -51,7 +51,7 @@ router bgp 65100
     neighbor 10.0.0.59 allowas-in 1
     neighbor 10.0.0.59 activate
     neighbor 10.0.0.59 soft-reconfiguration inbound
-    maximum-paths 64
+    maximum-paths 512
   exit-address-family
   neighbor fc00::76 remote-as 64600
   neighbor fc00::76 description ARISTA02T1
@@ -59,7 +59,7 @@ router bgp 65100
     neighbor fc00::76 allowas-in 1
     neighbor fc00::76 activate
     neighbor fc00::76 soft-reconfiguration inbound
-    maximum-paths 64
+    maximum-paths 512
   exit-address-family
   neighbor 10.0.0.61 remote-as 64600
   neighbor 10.0.0.61 description ARISTA03T1
@@ -67,7 +67,7 @@ router bgp 65100
     neighbor 10.0.0.61 allowas-in 1
     neighbor 10.0.0.61 activate
     neighbor 10.0.0.61 soft-reconfiguration inbound
-    maximum-paths 64
+    maximum-paths 512
   exit-address-family
   neighbor fc00::7a remote-as 64600
   neighbor fc00::7a description ARISTA03T1
@@ -75,7 +75,7 @@ router bgp 65100
     neighbor fc00::7a allowas-in 1
     neighbor fc00::7a activate
     neighbor fc00::7a soft-reconfiguration inbound
-    maximum-paths 64
+    maximum-paths 512
   exit-address-family
   neighbor 10.0.0.63 remote-as 64600
   neighbor 10.0.0.63 description ARISTA04T1
@@ -83,7 +83,7 @@ router bgp 65100
     neighbor 10.0.0.63 allowas-in 1
     neighbor 10.0.0.63 activate
     neighbor 10.0.0.63 soft-reconfiguration inbound
-    maximum-paths 64
+    maximum-paths 512
   exit-address-family
   neighbor fc00::7e remote-as 64600
   neighbor fc00::7e description ARISTA04T1
@@ -91,10 +91,10 @@ router bgp 65100
     neighbor fc00::7e allowas-in 1
     neighbor fc00::7e activate
     neighbor fc00::7e soft-reconfiguration inbound
-    maximum-paths 64
+    maximum-paths 512
   exit-address-family
 !
-maximum-paths 64
+maximum-paths 512
 !
 route-map ISOLATE permit 10
 set as-path prepend 65100

--- a/src/sonic-config-engine/tests/sample_output/py3/frr.conf
+++ b/src/sonic-config-engine/tests/sample_output/py3/frr.conf
@@ -87,10 +87,10 @@ router bgp 65100
 !
 !
   address-family ipv4
-    maximum-paths 64
+    maximum-paths 512
   exit-address-family
   address-family ipv6
-    maximum-paths 64
+    maximum-paths 512
   exit-address-family
 !
 ! end of template: bgpd/bgpd.main.conf.j2

--- a/src/sonic-config-engine/tests/sample_output/py3/t2-chassis-fe-bgpd.conf
+++ b/src/sonic-config-engine/tests/sample_output/py3/t2-chassis-fe-bgpd.conf
@@ -35,7 +35,7 @@ router bgp 4000 vrf VnetFE
   address-family ipv4 unicast
     neighbor 192.168.0.1 activate
     neighbor 192.168.0.1 soft-reconfiguration inbound
-    maximum-paths 64
+    maximum-paths 512
   exit-address-family
   address-family l2vpn evpn
     advertise ipv4 unicast
@@ -74,10 +74,10 @@ router bgp 4000
 !
 !
   address-family ipv4
-    maximum-paths 64
+    maximum-paths 512
   exit-address-family
   address-family ipv6
-    maximum-paths 64
+    maximum-paths 512
   exit-address-family
 !
 ! end of template: bgpd/bgpd.main.conf.j2


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Increasing the maximum-paths to 512. Currently value of 64 restricts the maximum paths that can created by BGP.
##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
Updated constants file.

#### How to verify it
Modified UT to verify.

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

