### PR TITLE
[BGP]Introduce bgp update delay to control how long bgp stays in readonly mode during init

### DIFF
--- a/dockers/docker-fpm-frr/frr/bgpd/bgpd.main.conf.j2
+++ b/dockers/docker-fpm-frr/frr/bgpd/bgpd.main.conf.j2
@@ -65,6 +65,10 @@ route-map HIDE_INTERNAL permit 20
 !
 {% endif %}
 !
+{% if constants.bgp.update_delay is defined %}
+bgp update-delay {{ constants.bgp.update_delay }}
+{% endif %}
+!
 {% if (DEVICE_METADATA is defined) and ('localhost' in DEVICE_METADATA) and ('bgp_asn' in DEVICE_METADATA['localhost']) and (DEVICE_METADATA['localhost']['bgp_asn'].lower() != 'none') and (DEVICE_METADATA['localhost']['bgp_asn'].lower() != 'null') %}
 router bgp {{ DEVICE_METADATA['localhost']['bgp_asn'] }}
 !

--- a/files/image_config/constants/constants.yml
+++ b/files/image_config/constants/constants.yml
@@ -24,6 +24,7 @@ constants:
       enabled: true
       ipv4: 514
       ipv6: 514
+    update_delay: 20
     allow_list:
       enabled: true
       default_action: "permit"   # or "deny"

--- a/src/sonic-config-engine/tests/sample_output/py2/bgpd_frr.conf
+++ b/src/sonic-config-engine/tests/sample_output/py2/bgpd_frr.conf
@@ -39,6 +39,8 @@ ip prefix-list LOCAL_VLAN_IPV4_PREFIX seq 10 permit 192.168.0.0/27
 !
 !
 !
+bgp update-delay 20
+!
 router bgp 65100
 !
   bgp log-neighbor-changes

--- a/src/sonic-config-engine/tests/sample_output/py2/bgpd_frr_backend_asic.conf
+++ b/src/sonic-config-engine/tests/sample_output/py2/bgpd_frr_backend_asic.conf
@@ -50,6 +50,8 @@ route-map HIDE_INTERNAL permit 10
   set community no-export
 !
 !
+bgp update-delay 20
+!
 router bgp 65100
 !
   bgp log-neighbor-changes

--- a/src/sonic-config-engine/tests/sample_output/py2/bgpd_frr_bmp.conf
+++ b/src/sonic-config-engine/tests/sample_output/py2/bgpd_frr_bmp.conf
@@ -39,6 +39,8 @@ ip prefix-list LOCAL_VLAN_IPV4_PREFIX seq 10 permit 192.168.200.0/27
 !
 !
 !
+bgp update-delay 20
+!
 router bgp 65100
 !
   bgp log-neighbor-changes

--- a/src/sonic-config-engine/tests/sample_output/py2/bgpd_frr_dualtor.conf
+++ b/src/sonic-config-engine/tests/sample_output/py2/bgpd_frr_dualtor.conf
@@ -39,6 +39,8 @@ ip prefix-list LOCAL_VLAN_IPV4_PREFIX seq 10 permit 192.168.0.0/27
 !
 !
 !
+bgp update-delay 20
+!
 router bgp 65100
 !
   bgp log-neighbor-changes

--- a/src/sonic-config-engine/tests/sample_output/py2/bgpd_frr_frontend_asic.conf
+++ b/src/sonic-config-engine/tests/sample_output/py2/bgpd_frr_frontend_asic.conf
@@ -50,6 +50,8 @@ route-map HIDE_INTERNAL permit 10
   set community no-export
 !
 !
+bgp update-delay 20
+!
 router bgp 65100
 !
   bgp log-neighbor-changes

--- a/src/sonic-config-engine/tests/sample_output/py2/bgpd_quagga.conf
+++ b/src/sonic-config-engine/tests/sample_output/py2/bgpd_quagga.conf
@@ -16,6 +16,8 @@ route-map FROM_BGP_SPEAKER_V4 permit 10
 !
 route-map TO_BGP_SPEAKER_V4 deny 10
 !
+bgp update-delay 20
+!
 router bgp 65100
   bgp log-neighbor-changes
   bgp bestpath as-path multipath-relax

--- a/src/sonic-config-engine/tests/sample_output/py2/frr.conf
+++ b/src/sonic-config-engine/tests/sample_output/py2/frr.conf
@@ -59,6 +59,8 @@ ip prefix-list LOCAL_VLAN_IPV4_PREFIX seq 10 permit 192.168.0.0/27
 !
 !
 !
+bgp update-delay 20
+!
 router bgp 65100
 !
   bgp log-neighbor-changes

--- a/src/sonic-config-engine/tests/sample_output/py2/t2-chassis-fe-bgpd.conf
+++ b/src/sonic-config-engine/tests/sample_output/py2/t2-chassis-fe-bgpd.conf
@@ -55,6 +55,8 @@ ip prefix-list PL_LoopbackV4 permit 4.0.0.0/32
 !
 !
 !
+bgp update-delay 20
+!
 router bgp 4000
 !
   bgp log-neighbor-changes

--- a/src/sonic-config-engine/tests/sample_output/py3/bgpd_frr.conf
+++ b/src/sonic-config-engine/tests/sample_output/py3/bgpd_frr.conf
@@ -39,6 +39,8 @@ ip prefix-list LOCAL_VLAN_IPV4_PREFIX seq 10 permit 192.168.200.0/27
 !
 !
 !
+bgp update-delay 20
+!
 router bgp 65100
 !
   bgp log-neighbor-changes

--- a/src/sonic-config-engine/tests/sample_output/py3/bgpd_frr_backend_asic.conf
+++ b/src/sonic-config-engine/tests/sample_output/py3/bgpd_frr_backend_asic.conf
@@ -50,6 +50,8 @@ route-map HIDE_INTERNAL permit 10
   set community no-export
 !
 !
+bgp update-delay 20
+!
 router bgp 65100
 !
   bgp log-neighbor-changes

--- a/src/sonic-config-engine/tests/sample_output/py3/bgpd_frr_bmp.conf
+++ b/src/sonic-config-engine/tests/sample_output/py3/bgpd_frr_bmp.conf
@@ -39,6 +39,8 @@ ip prefix-list LOCAL_VLAN_IPV4_PREFIX seq 10 permit 192.168.200.0/27
 !
 !
 !
+bgp update-delay 20
+!
 router bgp 65100
 !
   bgp log-neighbor-changes

--- a/src/sonic-config-engine/tests/sample_output/py3/bgpd_frr_dualtor.conf
+++ b/src/sonic-config-engine/tests/sample_output/py3/bgpd_frr_dualtor.conf
@@ -39,6 +39,8 @@ ip prefix-list LOCAL_VLAN_IPV4_PREFIX seq 10 permit 192.168.200.0/27
 !
 !
 !
+bgp update-delay 20
+!
 router bgp 65100
 !
   bgp log-neighbor-changes

--- a/src/sonic-config-engine/tests/sample_output/py3/bgpd_frr_frontend_asic.conf
+++ b/src/sonic-config-engine/tests/sample_output/py3/bgpd_frr_frontend_asic.conf
@@ -50,6 +50,8 @@ route-map HIDE_INTERNAL permit 10
   set community no-export
 !
 !
+bgp update-delay 20
+!
 router bgp 65100
 !
   bgp log-neighbor-changes

--- a/src/sonic-config-engine/tests/sample_output/py3/bgpd_quagga.conf
+++ b/src/sonic-config-engine/tests/sample_output/py3/bgpd_quagga.conf
@@ -16,6 +16,8 @@ route-map FROM_BGP_SPEAKER_V4 permit 10
 !
 route-map TO_BGP_SPEAKER_V4 deny 10
 !
+bgp update-delay 20
+!
 router bgp 65100
   bgp log-neighbor-changes
   bgp bestpath as-path multipath-relax

--- a/src/sonic-config-engine/tests/sample_output/py3/frr.conf
+++ b/src/sonic-config-engine/tests/sample_output/py3/frr.conf
@@ -59,6 +59,8 @@ ip prefix-list LOCAL_VLAN_IPV4_PREFIX seq 10 permit 192.168.200.0/27
 !
 !
 !
+bgp update-delay 20
+!
 router bgp 65100
 !
   bgp log-neighbor-changes

--- a/src/sonic-config-engine/tests/sample_output/py3/t2-chassis-fe-bgpd.conf
+++ b/src/sonic-config-engine/tests/sample_output/py3/t2-chassis-fe-bgpd.conf
@@ -55,6 +55,8 @@ ip prefix-list PL_LoopbackV4 permit 4.0.0.0/32
 !
 !
 !
+bgp update-delay 20
+!
 router bgp 4000
 !
   bgp log-neighbor-changes


### PR DESCRIPTION


<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Introduce bgp update delay to control how long bgp stays in readonly mode during init. Prevents churns during initialization and helps faster init times.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
Added constant and initialize update delay to 20.
#### How to verify it
Running BGP with scaled topology.
<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

