### PR TITLE
[Mellanox]Removing FEC from port_config.ini for SN5600 SKUs

### DIFF
--- a/device/mellanox/x86_64-nvidia_sn5600-r0/Mellanox-SN5600-C224O8/port_config.ini
+++ b/device/mellanox/x86_64-nvidia_sn5600-r0/Mellanox-SN5600-C224O8/port_config.ini
@@ -16,237 +16,237 @@
 ## limitations under the License.
 ##
 
-# name         lanes                                  alias     index    speed    fec   autoneg subport
-Ethernet0      0                                      etp1a     1        100000   rs    off     1
-Ethernet1      1                                      etp1b     1        100000   rs    off     2
-Ethernet2      2                                      etp1c     1        100000   rs    off     3
-Ethernet3      3                                      etp1d     1        100000   rs    off     4
-Ethernet4      4                                      etp1e     1        100000   rs    off     5
-Ethernet5      5                                      etp1f     1        100000   rs    off     6
-Ethernet6      6                                      etp1g     1        100000   rs    off     7
-Ethernet7      7                                      etp1h     1        100000   rs    off     8
-Ethernet16     16                                     etp3a     3        100000   rs    off     1
-Ethernet17     17                                     etp3b     3        100000   rs    off     2
-Ethernet18     18                                     etp3c     3        100000   rs    off     3
-Ethernet19     19                                     etp3d     3        100000   rs    off     4
-Ethernet20     20                                     etp3e     3        100000   rs    off     5
-Ethernet21     21                                     etp3f     3        100000   rs    off     6
-Ethernet22     22                                     etp3g     3        100000   rs    off     7
-Ethernet23     23                                     etp3h     3        100000   rs    off     8
-Ethernet32     32                                     etp5a     5        100000   rs    off     1
-Ethernet33     33                                     etp5b     5        100000   rs    off     2
-Ethernet34     34                                     etp5c     5        100000   rs    off     3
-Ethernet35     35                                     etp5d     5        100000   rs    off     4
-Ethernet36     36                                     etp5e     5        100000   rs    off     5
-Ethernet37     37                                     etp5f     5        100000   rs    off     6
-Ethernet38     38                                     etp5g     5        100000   rs    off     7
-Ethernet39     39                                     etp5h     5        100000   rs    off     8
-Ethernet48     48                                     etp7a     7        100000   rs    off     1
-Ethernet49     49                                     etp7b     7        100000   rs    off     2
-Ethernet50     50                                     etp7c     7        100000   rs    off     3
-Ethernet51     51                                     etp7d     7        100000   rs    off     4
-Ethernet52     52                                     etp7e     7        100000   rs    off     5
-Ethernet53     53                                     etp7f     7        100000   rs    off     6
-Ethernet54     54                                     etp7g     7        100000   rs    off     7
-Ethernet55     55                                     etp7h     7        100000   rs    off     8
-Ethernet64     64                                     etp9a     9        100000   rs    off     1
-Ethernet65     65                                     etp9b     9        100000   rs    off     2
-Ethernet66     66                                     etp9c     9        100000   rs    off     3
-Ethernet67     67                                     etp9d     9        100000   rs    off     4
-Ethernet68     68                                     etp9e     9        100000   rs    off     5
-Ethernet69     69                                     etp9f     9        100000   rs    off     6
-Ethernet70     70                                     etp9g     9        100000   rs    off     7
-Ethernet71     71                                     etp9h     9        100000   rs    off     8
-Ethernet80     80                                     etp11a    11       100000   rs    off     1
-Ethernet81     81                                     etp11b    11       100000   rs    off     2
-Ethernet82     82                                     etp11c    11       100000   rs    off     3
-Ethernet83     83                                     etp11d    11       100000   rs    off     4
-Ethernet84     84                                     etp11e    11       100000   rs    off     5
-Ethernet85     85                                     etp11f    11       100000   rs    off     6
-Ethernet86     86                                     etp11g    11       100000   rs    off     7
-Ethernet87     87                                     etp11h    11       100000   rs    off     8
-Ethernet96     96,97,98,99                            etp13a    13       400000   rs    off     1
-Ethernet100    100,101,102,103                        etp13b    13       400000   rs    off     2
-Ethernet112    112                                    etp15a    15       100000   rs    off     1
-Ethernet113    113                                    etp15b    15       100000   rs    off     2
-Ethernet114    114                                    etp15c    15       100000   rs    off     3
-Ethernet115    115                                    etp15d    15       100000   rs    off     4
-Ethernet116    116                                    etp15e    15       100000   rs    off     5
-Ethernet117    117                                    etp15f    15       100000   rs    off     6
-Ethernet118    118                                    etp15g    15       100000   rs    off     7
-Ethernet119    119                                    etp15h    15       100000   rs    off     8
-Ethernet128    128,129,130,131                        etp17a    17       400000   rs    off     1
-Ethernet132    132,133,134,135                        etp17b    17       400000   rs    off     2
-Ethernet144    144                                    etp19a    19       100000   rs    off     1
-Ethernet145    145                                    etp19b    19       100000   rs    off     2
-Ethernet146    146                                    etp19c    19       100000   rs    off     3
-Ethernet147    147                                    etp19d    19       100000   rs    off     4
-Ethernet148    148                                    etp19e    19       100000   rs    off     5
-Ethernet149    149                                    etp19f    19       100000   rs    off     6
-Ethernet150    150                                    etp19g    19       100000   rs    off     7
-Ethernet151    151                                    etp19h    19       100000   rs    off     8
-Ethernet160    160                                    etp21a    21       100000   rs    off     1
-Ethernet161    161                                    etp21b    21       100000   rs    off     2
-Ethernet162    162                                    etp21c    21       100000   rs    off     3
-Ethernet163    163                                    etp21d    21       100000   rs    off     4
-Ethernet164    164                                    etp21e    21       100000   rs    off     5
-Ethernet165    165                                    etp21f    21       100000   rs    off     6
-Ethernet166    166                                    etp21g    21       100000   rs    off     7
-Ethernet167    167                                    etp21h    21       100000   rs    off     8
-Ethernet176    176                                    etp23a    23       100000   rs    off     1
-Ethernet177    177                                    etp23b    23       100000   rs    off     2
-Ethernet178    178                                    etp23c    23       100000   rs    off     3
-Ethernet179    179                                    etp23d    23       100000   rs    off     4
-Ethernet180    180                                    etp23e    23       100000   rs    off     5
-Ethernet181    181                                    etp23f    23       100000   rs    off     6
-Ethernet182    182                                    etp23g    23       100000   rs    off     7
-Ethernet183    183                                    etp23h    23       100000   rs    off     8
-Ethernet192    192                                    etp25a    25       100000   rs    off     1
-Ethernet193    193                                    etp25b    25       100000   rs    off     2
-Ethernet194    194                                    etp25c    25       100000   rs    off     3
-Ethernet195    195                                    etp25d    25       100000   rs    off     4
-Ethernet196    196                                    etp25e    25       100000   rs    off     5
-Ethernet197    197                                    etp25f    25       100000   rs    off     6
-Ethernet198    198                                    etp25g    25       100000   rs    off     7
-Ethernet199    199                                    etp25h    25       100000   rs    off     8
-Ethernet208    208                                    etp27a    27       100000   rs    off     1
-Ethernet209    209                                    etp27b    27       100000   rs    off     2
-Ethernet210    210                                    etp27c    27       100000   rs    off     3
-Ethernet211    211                                    etp27d    27       100000   rs    off     4
-Ethernet212    212                                    etp27e    27       100000   rs    off     5
-Ethernet213    213                                    etp27f    27       100000   rs    off     6
-Ethernet214    214                                    etp27g    27       100000   rs    off     7
-Ethernet215    215                                    etp27h    27       100000   rs    off     8
-Ethernet224    224                                    etp29a    29       100000   rs    off     1
-Ethernet225    225                                    etp29b    29       100000   rs    off     2
-Ethernet226    226                                    etp29c    29       100000   rs    off     3
-Ethernet227    227                                    etp29d    29       100000   rs    off     4
-Ethernet228    228                                    etp29e    29       100000   rs    off     5
-Ethernet229    229                                    etp29f    29       100000   rs    off     6
-Ethernet230    230                                    etp29g    29       100000   rs    off     7
-Ethernet231    231                                    etp29h    29       100000   rs    off     8
-Ethernet240    240                                    etp31a    31       100000   rs    off     1
-Ethernet241    241                                    etp31b    31       100000   rs    off     2
-Ethernet242    242                                    etp31c    31       100000   rs    off     3
-Ethernet243    243                                    etp31d    31       100000   rs    off     4
-Ethernet244    244                                    etp31e    31       100000   rs    off     5
-Ethernet245    245                                    etp31f    31       100000   rs    off     6
-Ethernet246    246                                    etp31g    31       100000   rs    off     7
-Ethernet247    247                                    etp31h    31       100000   rs    off     8
-Ethernet256    256                                    etp33a    33       100000   rs    off     1
-Ethernet257    257                                    etp33b    33       100000   rs    off     2
-Ethernet258    258                                    etp33c    33       100000   rs    off     3
-Ethernet259    259                                    etp33d    33       100000   rs    off     4
-Ethernet260    260                                    etp33e    33       100000   rs    off     5
-Ethernet261    261                                    etp33f    33       100000   rs    off     6
-Ethernet262    262                                    etp33g    33       100000   rs    off     7
-Ethernet263    263                                    etp33h    33       100000   rs    off     8
-Ethernet272    272                                    etp35a    35       100000   rs    off     1
-Ethernet273    273                                    etp35b    35       100000   rs    off     2
-Ethernet274    274                                    etp35c    35       100000   rs    off     3
-Ethernet275    275                                    etp35d    35       100000   rs    off     4
-Ethernet276    276                                    etp35e    35       100000   rs    off     5
-Ethernet277    277                                    etp35f    35       100000   rs    off     6
-Ethernet278    278                                    etp35g    35       100000   rs    off     7
-Ethernet279    279                                    etp35h    35       100000   rs    off     8
-Ethernet288    288                                    etp37a    37       100000   rs    off     1
-Ethernet289    289                                    etp37b    37       100000   rs    off     2
-Ethernet290    290                                    etp37c    37       100000   rs    off     3
-Ethernet291    291                                    etp37d    37       100000   rs    off     4
-Ethernet292    292                                    etp37e    37       100000   rs    off     5
-Ethernet293    293                                    etp37f    37       100000   rs    off     6
-Ethernet294    294                                    etp37g    37       100000   rs    off     7
-Ethernet295    295                                    etp37h    37       100000   rs    off     8
-Ethernet304    304                                    etp39a    39       100000   rs    off     1
-Ethernet305    305                                    etp39b    39       100000   rs    off     2
-Ethernet306    306                                    etp39c    39       100000   rs    off     3
-Ethernet307    307                                    etp39d    39       100000   rs    off     4
-Ethernet308    308                                    etp39e    39       100000   rs    off     5
-Ethernet309    309                                    etp39f    39       100000   rs    off     6
-Ethernet310    310                                    etp39g    39       100000   rs    off     7
-Ethernet311    311                                    etp39h    39       100000   rs    off     8
-Ethernet320    320                                    etp41a    41       100000   rs    off     1
-Ethernet321    321                                    etp41b    41       100000   rs    off     2
-Ethernet322    322                                    etp41c    41       100000   rs    off     3
-Ethernet323    323                                    etp41d    41       100000   rs    off     4
-Ethernet324    324                                    etp41e    41       100000   rs    off     5
-Ethernet325    325                                    etp41f    41       100000   rs    off     6
-Ethernet326    326                                    etp41g    41       100000   rs    off     7
-Ethernet327    327                                    etp41h    41       100000   rs    off     8
-Ethernet336    336                                    etp43a    43       100000   rs    off     1
-Ethernet337    337                                    etp43b    43       100000   rs    off     2
-Ethernet338    338                                    etp43c    43       100000   rs    off     3
-Ethernet339    339                                    etp43d    43       100000   rs    off     4
-Ethernet340    340                                    etp43e    43       100000   rs    off     5
-Ethernet341    341                                    etp43f    43       100000   rs    off     6
-Ethernet342    342                                    etp43g    43       100000   rs    off     7
-Ethernet343    343                                    etp43h    43       100000   rs    off     8
-Ethernet352    352,353,354,355                        etp45a    45       400000   rs    off     1
-Ethernet356    356,357,358,359                        etp45b    45       400000   rs    off     2
-Ethernet368    368                                    etp47a    47       100000   rs    off     1
-Ethernet369    369                                    etp47b    47       100000   rs    off     2
-Ethernet370    370                                    etp47c    47       100000   rs    off     3
-Ethernet371    371                                    etp47d    47       100000   rs    off     4
-Ethernet372    372                                    etp47e    47       100000   rs    off     5
-Ethernet373    373                                    etp47f    47       100000   rs    off     6
-Ethernet374    374                                    etp47g    47       100000   rs    off     7
-Ethernet375    375                                    etp47h    47       100000   rs    off     8
-Ethernet384    384,385,386,387                        etp49a    49       400000   rs    off     1
-Ethernet388    388,389,390,391                        etp49b    49       400000   rs    off     2
-Ethernet400    400                                    etp51a    51       100000   rs    off     1
-Ethernet401    401                                    etp51b    51       100000   rs    off     2
-Ethernet402    402                                    etp51c    51       100000   rs    off     3
-Ethernet403    403                                    etp51d    51       100000   rs    off     4
-Ethernet404    404                                    etp51e    51       100000   rs    off     5
-Ethernet405    405                                    etp51f    51       100000   rs    off     6
-Ethernet406    406                                    etp51g    51       100000   rs    off     7
-Ethernet407    407                                    etp51h    51       100000   rs    off     8
-Ethernet416    416                                    etp53a    53       100000   rs    off     1
-Ethernet417    417                                    etp53b    53       100000   rs    off     2
-Ethernet418    418                                    etp53c    53       100000   rs    off     3
-Ethernet419    419                                    etp53d    53       100000   rs    off     4
-Ethernet420    420                                    etp53e    53       100000   rs    off     5
-Ethernet421    421                                    etp53f    53       100000   rs    off     6
-Ethernet422    422                                    etp53g    53       100000   rs    off     7
-Ethernet423    423                                    etp53h    53       100000   rs    off     8
-Ethernet432    432                                    etp55a    55       100000   rs    off     1
-Ethernet433    433                                    etp55b    55       100000   rs    off     2
-Ethernet434    434                                    etp55c    55       100000   rs    off     3
-Ethernet435    435                                    etp55d    55       100000   rs    off     4
-Ethernet436    436                                    etp55e    55       100000   rs    off     5
-Ethernet437    437                                    etp55f    55       100000   rs    off     6
-Ethernet438    438                                    etp55g    55       100000   rs    off     7
-Ethernet439    439                                    etp55h    55       100000   rs    off     8
-Ethernet448    448                                    etp57a    57       100000   rs    off     1
-Ethernet449    449                                    etp57b    57       100000   rs    off     2
-Ethernet450    450                                    etp57c    57       100000   rs    off     3
-Ethernet451    451                                    etp57d    57       100000   rs    off     4
-Ethernet452    452                                    etp57e    57       100000   rs    off     5
-Ethernet453    453                                    etp57f    57       100000   rs    off     6
-Ethernet454    454                                    etp57g    57       100000   rs    off     7
-Ethernet455    455                                    etp57h    57       100000   rs    off     8
-Ethernet464    464                                    etp59a    59       100000   rs    off     1
-Ethernet465    465                                    etp59b    59       100000   rs    off     2
-Ethernet466    466                                    etp59c    59       100000   rs    off     3
-Ethernet467    467                                    etp59d    59       100000   rs    off     4
-Ethernet468    468                                    etp59e    59       100000   rs    off     5
-Ethernet469    469                                    etp59f    59       100000   rs    off     6
-Ethernet470    470                                    etp59g    59       100000   rs    off     7
-Ethernet471    471                                    etp59h    59       100000   rs    off     8
-Ethernet480    480                                    etp61a    61       100000   rs    off     1
-Ethernet481    481                                    etp61b    61       100000   rs    off     2
-Ethernet482    482                                    etp61c    61       100000   rs    off     3
-Ethernet483    483                                    etp61d    61       100000   rs    off     4
-Ethernet484    484                                    etp61e    61       100000   rs    off     5
-Ethernet485    485                                    etp61f    61       100000   rs    off     6
-Ethernet486    486                                    etp61g    61       100000   rs    off     7
-Ethernet487    487                                    etp61h    61       100000   rs    off     8
-Ethernet496    496                                    etp63a    63       100000   rs    off     1
-Ethernet497    497                                    etp63b    63       100000   rs    off     2
-Ethernet498    498                                    etp63c    63       100000   rs    off     3
-Ethernet499    499                                    etp63d    63       100000   rs    off     4
-Ethernet500    500                                    etp63e    63       100000   rs    off     5
-Ethernet501    501                                    etp63f    63       100000   rs    off     6
-Ethernet502    502                                    etp63g    63       100000   rs    off     7
-Ethernet503    503                                    etp63h    63       100000   rs    off     8
-Ethernet512    512                                    etp65     65        10000   rs
+# name         lanes                                  alias     index    speed    autoneg subport
+Ethernet0      0                                      etp1a     1        100000   off     1
+Ethernet1      1                                      etp1b     1        100000   off     2
+Ethernet2      2                                      etp1c     1        100000   off     3
+Ethernet3      3                                      etp1d     1        100000   off     4
+Ethernet4      4                                      etp1e     1        100000   off     5
+Ethernet5      5                                      etp1f     1        100000   off     6
+Ethernet6      6                                      etp1g     1        100000   off     7
+Ethernet7      7                                      etp1h     1        100000   off     8
+Ethernet16     16                                     etp3a     3        100000   off     1
+Ethernet17     17                                     etp3b     3        100000   off     2
+Ethernet18     18                                     etp3c     3        100000   off     3
+Ethernet19     19                                     etp3d     3        100000   off     4
+Ethernet20     20                                     etp3e     3        100000   off     5
+Ethernet21     21                                     etp3f     3        100000   off     6
+Ethernet22     22                                     etp3g     3        100000   off     7
+Ethernet23     23                                     etp3h     3        100000   off     8
+Ethernet32     32                                     etp5a     5        100000   off     1
+Ethernet33     33                                     etp5b     5        100000   off     2
+Ethernet34     34                                     etp5c     5        100000   off     3
+Ethernet35     35                                     etp5d     5        100000   off     4
+Ethernet36     36                                     etp5e     5        100000   off     5
+Ethernet37     37                                     etp5f     5        100000   off     6
+Ethernet38     38                                     etp5g     5        100000   off     7
+Ethernet39     39                                     etp5h     5        100000   off     8
+Ethernet48     48                                     etp7a     7        100000   off     1
+Ethernet49     49                                     etp7b     7        100000   off     2
+Ethernet50     50                                     etp7c     7        100000   off     3
+Ethernet51     51                                     etp7d     7        100000   off     4
+Ethernet52     52                                     etp7e     7        100000   off     5
+Ethernet53     53                                     etp7f     7        100000   off     6
+Ethernet54     54                                     etp7g     7        100000   off     7
+Ethernet55     55                                     etp7h     7        100000   off     8
+Ethernet64     64                                     etp9a     9        100000   off     1
+Ethernet65     65                                     etp9b     9        100000   off     2
+Ethernet66     66                                     etp9c     9        100000   off     3
+Ethernet67     67                                     etp9d     9        100000   off     4
+Ethernet68     68                                     etp9e     9        100000   off     5
+Ethernet69     69                                     etp9f     9        100000   off     6
+Ethernet70     70                                     etp9g     9        100000   off     7
+Ethernet71     71                                     etp9h     9        100000   off     8
+Ethernet80     80                                     etp11a    11       100000   off     1
+Ethernet81     81                                     etp11b    11       100000   off     2
+Ethernet82     82                                     etp11c    11       100000   off     3
+Ethernet83     83                                     etp11d    11       100000   off     4
+Ethernet84     84                                     etp11e    11       100000   off     5
+Ethernet85     85                                     etp11f    11       100000   off     6
+Ethernet86     86                                     etp11g    11       100000   off     7
+Ethernet87     87                                     etp11h    11       100000   off     8
+Ethernet96     96,97,98,99                            etp13a    13       400000   off     1
+Ethernet100    100,101,102,103                        etp13b    13       400000   off     2
+Ethernet112    112                                    etp15a    15       100000   off     1
+Ethernet113    113                                    etp15b    15       100000   off     2
+Ethernet114    114                                    etp15c    15       100000   off     3
+Ethernet115    115                                    etp15d    15       100000   off     4
+Ethernet116    116                                    etp15e    15       100000   off     5
+Ethernet117    117                                    etp15f    15       100000   off     6
+Ethernet118    118                                    etp15g    15       100000   off     7
+Ethernet119    119                                    etp15h    15       100000   off     8
+Ethernet128    128,129,130,131                        etp17a    17       400000   off     1
+Ethernet132    132,133,134,135                        etp17b    17       400000   off     2
+Ethernet144    144                                    etp19a    19       100000   off     1
+Ethernet145    145                                    etp19b    19       100000   off     2
+Ethernet146    146                                    etp19c    19       100000   off     3
+Ethernet147    147                                    etp19d    19       100000   off     4
+Ethernet148    148                                    etp19e    19       100000   off     5
+Ethernet149    149                                    etp19f    19       100000   off     6
+Ethernet150    150                                    etp19g    19       100000   off     7
+Ethernet151    151                                    etp19h    19       100000   off     8
+Ethernet160    160                                    etp21a    21       100000   off     1
+Ethernet161    161                                    etp21b    21       100000   off     2
+Ethernet162    162                                    etp21c    21       100000   off     3
+Ethernet163    163                                    etp21d    21       100000   off     4
+Ethernet164    164                                    etp21e    21       100000   off     5
+Ethernet165    165                                    etp21f    21       100000   off     6
+Ethernet166    166                                    etp21g    21       100000   off     7
+Ethernet167    167                                    etp21h    21       100000   off     8
+Ethernet176    176                                    etp23a    23       100000   off     1
+Ethernet177    177                                    etp23b    23       100000   off     2
+Ethernet178    178                                    etp23c    23       100000   off     3
+Ethernet179    179                                    etp23d    23       100000   off     4
+Ethernet180    180                                    etp23e    23       100000   off     5
+Ethernet181    181                                    etp23f    23       100000   off     6
+Ethernet182    182                                    etp23g    23       100000   off     7
+Ethernet183    183                                    etp23h    23       100000   off     8
+Ethernet192    192                                    etp25a    25       100000   off     1
+Ethernet193    193                                    etp25b    25       100000   off     2
+Ethernet194    194                                    etp25c    25       100000   off     3
+Ethernet195    195                                    etp25d    25       100000   off     4
+Ethernet196    196                                    etp25e    25       100000   off     5
+Ethernet197    197                                    etp25f    25       100000   off     6
+Ethernet198    198                                    etp25g    25       100000   off     7
+Ethernet199    199                                    etp25h    25       100000   off     8
+Ethernet208    208                                    etp27a    27       100000   off     1
+Ethernet209    209                                    etp27b    27       100000   off     2
+Ethernet210    210                                    etp27c    27       100000   off     3
+Ethernet211    211                                    etp27d    27       100000   off     4
+Ethernet212    212                                    etp27e    27       100000   off     5
+Ethernet213    213                                    etp27f    27       100000   off     6
+Ethernet214    214                                    etp27g    27       100000   off     7
+Ethernet215    215                                    etp27h    27       100000   off     8
+Ethernet224    224                                    etp29a    29       100000   off     1
+Ethernet225    225                                    etp29b    29       100000   off     2
+Ethernet226    226                                    etp29c    29       100000   off     3
+Ethernet227    227                                    etp29d    29       100000   off     4
+Ethernet228    228                                    etp29e    29       100000   off     5
+Ethernet229    229                                    etp29f    29       100000   off     6
+Ethernet230    230                                    etp29g    29       100000   off     7
+Ethernet231    231                                    etp29h    29       100000   off     8
+Ethernet240    240                                    etp31a    31       100000   off     1
+Ethernet241    241                                    etp31b    31       100000   off     2
+Ethernet242    242                                    etp31c    31       100000   off     3
+Ethernet243    243                                    etp31d    31       100000   off     4
+Ethernet244    244                                    etp31e    31       100000   off     5
+Ethernet245    245                                    etp31f    31       100000   off     6
+Ethernet246    246                                    etp31g    31       100000   off     7
+Ethernet247    247                                    etp31h    31       100000   off     8
+Ethernet256    256                                    etp33a    33       100000   off     1
+Ethernet257    257                                    etp33b    33       100000   off     2
+Ethernet258    258                                    etp33c    33       100000   off     3
+Ethernet259    259                                    etp33d    33       100000   off     4
+Ethernet260    260                                    etp33e    33       100000   off     5
+Ethernet261    261                                    etp33f    33       100000   off     6
+Ethernet262    262                                    etp33g    33       100000   off     7
+Ethernet263    263                                    etp33h    33       100000   off     8
+Ethernet272    272                                    etp35a    35       100000   off     1
+Ethernet273    273                                    etp35b    35       100000   off     2
+Ethernet274    274                                    etp35c    35       100000   off     3
+Ethernet275    275                                    etp35d    35       100000   off     4
+Ethernet276    276                                    etp35e    35       100000   off     5
+Ethernet277    277                                    etp35f    35       100000   off     6
+Ethernet278    278                                    etp35g    35       100000   off     7
+Ethernet279    279                                    etp35h    35       100000   off     8
+Ethernet288    288                                    etp37a    37       100000   off     1
+Ethernet289    289                                    etp37b    37       100000   off     2
+Ethernet290    290                                    etp37c    37       100000   off     3
+Ethernet291    291                                    etp37d    37       100000   off     4
+Ethernet292    292                                    etp37e    37       100000   off     5
+Ethernet293    293                                    etp37f    37       100000   off     6
+Ethernet294    294                                    etp37g    37       100000   off     7
+Ethernet295    295                                    etp37h    37       100000   off     8
+Ethernet304    304                                    etp39a    39       100000   off     1
+Ethernet305    305                                    etp39b    39       100000   off     2
+Ethernet306    306                                    etp39c    39       100000   off     3
+Ethernet307    307                                    etp39d    39       100000   off     4
+Ethernet308    308                                    etp39e    39       100000   off     5
+Ethernet309    309                                    etp39f    39       100000   off     6
+Ethernet310    310                                    etp39g    39       100000   off     7
+Ethernet311    311                                    etp39h    39       100000   off     8
+Ethernet320    320                                    etp41a    41       100000   off     1
+Ethernet321    321                                    etp41b    41       100000   off     2
+Ethernet322    322                                    etp41c    41       100000   off     3
+Ethernet323    323                                    etp41d    41       100000   off     4
+Ethernet324    324                                    etp41e    41       100000   off     5
+Ethernet325    325                                    etp41f    41       100000   off     6
+Ethernet326    326                                    etp41g    41       100000   off     7
+Ethernet327    327                                    etp41h    41       100000   off     8
+Ethernet336    336                                    etp43a    43       100000   off     1
+Ethernet337    337                                    etp43b    43       100000   off     2
+Ethernet338    338                                    etp43c    43       100000   off     3
+Ethernet339    339                                    etp43d    43       100000   off     4
+Ethernet340    340                                    etp43e    43       100000   off     5
+Ethernet341    341                                    etp43f    43       100000   off     6
+Ethernet342    342                                    etp43g    43       100000   off     7
+Ethernet343    343                                    etp43h    43       100000   off     8
+Ethernet352    352,353,354,355                        etp45a    45       400000   off     1
+Ethernet356    356,357,358,359                        etp45b    45       400000   off     2
+Ethernet368    368                                    etp47a    47       100000   off     1
+Ethernet369    369                                    etp47b    47       100000   off     2
+Ethernet370    370                                    etp47c    47       100000   off     3
+Ethernet371    371                                    etp47d    47       100000   off     4
+Ethernet372    372                                    etp47e    47       100000   off     5
+Ethernet373    373                                    etp47f    47       100000   off     6
+Ethernet374    374                                    etp47g    47       100000   off     7
+Ethernet375    375                                    etp47h    47       100000   off     8
+Ethernet384    384,385,386,387                        etp49a    49       400000   off     1
+Ethernet388    388,389,390,391                        etp49b    49       400000   off     2
+Ethernet400    400                                    etp51a    51       100000   off     1
+Ethernet401    401                                    etp51b    51       100000   off     2
+Ethernet402    402                                    etp51c    51       100000   off     3
+Ethernet403    403                                    etp51d    51       100000   off     4
+Ethernet404    404                                    etp51e    51       100000   off     5
+Ethernet405    405                                    etp51f    51       100000   off     6
+Ethernet406    406                                    etp51g    51       100000   off     7
+Ethernet407    407                                    etp51h    51       100000   off     8
+Ethernet416    416                                    etp53a    53       100000   off     1
+Ethernet417    417                                    etp53b    53       100000   off     2
+Ethernet418    418                                    etp53c    53       100000   off     3
+Ethernet419    419                                    etp53d    53       100000   off     4
+Ethernet420    420                                    etp53e    53       100000   off     5
+Ethernet421    421                                    etp53f    53       100000   off     6
+Ethernet422    422                                    etp53g    53       100000   off     7
+Ethernet423    423                                    etp53h    53       100000   off     8
+Ethernet432    432                                    etp55a    55       100000   off     1
+Ethernet433    433                                    etp55b    55       100000   off     2
+Ethernet434    434                                    etp55c    55       100000   off     3
+Ethernet435    435                                    etp55d    55       100000   off     4
+Ethernet436    436                                    etp55e    55       100000   off     5
+Ethernet437    437                                    etp55f    55       100000   off     6
+Ethernet438    438                                    etp55g    55       100000   off     7
+Ethernet439    439                                    etp55h    55       100000   off     8
+Ethernet448    448                                    etp57a    57       100000   off     1
+Ethernet449    449                                    etp57b    57       100000   off     2
+Ethernet450    450                                    etp57c    57       100000   off     3
+Ethernet451    451                                    etp57d    57       100000   off     4
+Ethernet452    452                                    etp57e    57       100000   off     5
+Ethernet453    453                                    etp57f    57       100000   off     6
+Ethernet454    454                                    etp57g    57       100000   off     7
+Ethernet455    455                                    etp57h    57       100000   off     8
+Ethernet464    464                                    etp59a    59       100000   off     1
+Ethernet465    465                                    etp59b    59       100000   off     2
+Ethernet466    466                                    etp59c    59       100000   off     3
+Ethernet467    467                                    etp59d    59       100000   off     4
+Ethernet468    468                                    etp59e    59       100000   off     5
+Ethernet469    469                                    etp59f    59       100000   off     6
+Ethernet470    470                                    etp59g    59       100000   off     7
+Ethernet471    471                                    etp59h    59       100000   off     8
+Ethernet480    480                                    etp61a    61       100000   off     1
+Ethernet481    481                                    etp61b    61       100000   off     2
+Ethernet482    482                                    etp61c    61       100000   off     3
+Ethernet483    483                                    etp61d    61       100000   off     4
+Ethernet484    484                                    etp61e    61       100000   off     5
+Ethernet485    485                                    etp61f    61       100000   off     6
+Ethernet486    486                                    etp61g    61       100000   off     7
+Ethernet487    487                                    etp61h    61       100000   off     8
+Ethernet496    496                                    etp63a    63       100000   off     1
+Ethernet497    497                                    etp63b    63       100000   off     2
+Ethernet498    498                                    etp63c    63       100000   off     3
+Ethernet499    499                                    etp63d    63       100000   off     4
+Ethernet500    500                                    etp63e    63       100000   off     5
+Ethernet501    501                                    etp63f    63       100000   off     6
+Ethernet502    502                                    etp63g    63       100000   off     7
+Ethernet503    503                                    etp63h    63       100000   off     8
+Ethernet512    512                                    etp65     65        10000

--- a/device/mellanox/x86_64-nvidia_sn5600-r0/Mellanox-SN5600-C256S1/port_config.ini
+++ b/device/mellanox/x86_64-nvidia_sn5600-r0/Mellanox-SN5600-C256S1/port_config.ini
@@ -16,261 +16,261 @@
 ## limitations under the License.
 ##
 
-# name         lanes                                  alias     index    speed    fec   autoneg subport
-Ethernet0      0                                      etp1a     1        100000   rs    off     1
-Ethernet1      1                                      etp1b     1        100000   rs    off     2
-Ethernet2      2                                      etp1c     1        100000   rs    off     3
-Ethernet3      3                                      etp1d     1        100000   rs    off     4
-Ethernet4      4                                      etp1e     1        100000   rs    off     5
-Ethernet5      5                                      etp1f     1        100000   rs    off     6
-Ethernet6      6                                      etp1g     1        100000   rs    off     7
-Ethernet7      7                                      etp1h     1        100000   rs    off     8
-Ethernet16     16                                     etp3a     3        100000   rs    off     1
-Ethernet17     17                                     etp3b     3        100000   rs    off     2
-Ethernet18     18                                     etp3c     3        100000   rs    off     3
-Ethernet19     19                                     etp3d     3        100000   rs    off     4
-Ethernet20     20                                     etp3e     3        100000   rs    off     5
-Ethernet21     21                                     etp3f     3        100000   rs    off     6
-Ethernet22     22                                     etp3g     3        100000   rs    off     7
-Ethernet23     23                                     etp3h     3        100000   rs    off     8
-Ethernet32     32                                     etp5a     5        100000   rs    off     1
-Ethernet33     33                                     etp5b     5        100000   rs    off     2
-Ethernet34     34                                     etp5c     5        100000   rs    off     3
-Ethernet35     35                                     etp5d     5        100000   rs    off     4
-Ethernet36     36                                     etp5e     5        100000   rs    off     5
-Ethernet37     37                                     etp5f     5        100000   rs    off     6
-Ethernet38     38                                     etp5g     5        100000   rs    off     7
-Ethernet39     39                                     etp5h     5        100000   rs    off     8
-Ethernet48     48                                     etp7a     7        100000   rs    off     1
-Ethernet49     49                                     etp7b     7        100000   rs    off     2
-Ethernet50     50                                     etp7c     7        100000   rs    off     3
-Ethernet51     51                                     etp7d     7        100000   rs    off     4
-Ethernet52     52                                     etp7e     7        100000   rs    off     5
-Ethernet53     53                                     etp7f     7        100000   rs    off     6
-Ethernet54     54                                     etp7g     7        100000   rs    off     7
-Ethernet55     55                                     etp7h     7        100000   rs    off     8
-Ethernet64     64                                     etp9a     9        100000   rs    off     1
-Ethernet65     65                                     etp9b     9        100000   rs    off     2
-Ethernet66     66                                     etp9c     9        100000   rs    off     3
-Ethernet67     67                                     etp9d     9        100000   rs    off     4
-Ethernet68     68                                     etp9e     9        100000   rs    off     5
-Ethernet69     69                                     etp9f     9        100000   rs    off     6
-Ethernet70     70                                     etp9g     9        100000   rs    off     7
-Ethernet71     71                                     etp9h     9        100000   rs    off     8
-Ethernet80     80                                     etp11a    11       100000   rs    off     1
-Ethernet81     81                                     etp11b    11       100000   rs    off     2
-Ethernet82     82                                     etp11c    11       100000   rs    off     3
-Ethernet83     83                                     etp11d    11       100000   rs    off     4
-Ethernet84     84                                     etp11e    11       100000   rs    off     5
-Ethernet85     85                                     etp11f    11       100000   rs    off     6
-Ethernet86     86                                     etp11g    11       100000   rs    off     7
-Ethernet87     87                                     etp11h    11       100000   rs    off     8
-Ethernet96     96                                     etp13a    13       100000   rs    off     1
-Ethernet97     97                                     etp13b    13       100000   rs    off     2
-Ethernet98     98                                     etp13c    13       100000   rs    off     3
-Ethernet99     99                                     etp13d    13       100000   rs    off     4
-Ethernet100    100                                    etp13e    13       100000   rs    off     5
-Ethernet101    101                                    etp13f    13       100000   rs    off     6
-Ethernet102    102                                    etp13g    13       100000   rs    off     7
-Ethernet103    103                                    etp13h    13       100000   rs    off     8
-Ethernet112    112                                    etp15a    15       100000   rs    off     1
-Ethernet113    113                                    etp15b    15       100000   rs    off     2
-Ethernet114    114                                    etp15c    15       100000   rs    off     3
-Ethernet115    115                                    etp15d    15       100000   rs    off     4
-Ethernet116    116                                    etp15e    15       100000   rs    off     5
-Ethernet117    117                                    etp15f    15       100000   rs    off     6
-Ethernet118    118                                    etp15g    15       100000   rs    off     7
-Ethernet119    119                                    etp15h    15       100000   rs    off     8
-Ethernet128    128                                    etp17a    17       100000   rs    off     1
-Ethernet129    129                                    etp17b    17       100000   rs    off     2
-Ethernet130    130                                    etp17c    17       100000   rs    off     3
-Ethernet131    131                                    etp17d    17       100000   rs    off     4
-Ethernet132    132                                    etp17e    17       100000   rs    off     5
-Ethernet133    133                                    etp17f    17       100000   rs    off     6
-Ethernet134    134                                    etp17g    17       100000   rs    off     7
-Ethernet135    135                                    etp17h    17       100000   rs    off     8
-Ethernet144    144                                    etp19a    19       100000   rs    off     1
-Ethernet145    145                                    etp19b    19       100000   rs    off     2
-Ethernet146    146                                    etp19c    19       100000   rs    off     3
-Ethernet147    147                                    etp19d    19       100000   rs    off     4
-Ethernet148    148                                    etp19e    19       100000   rs    off     5
-Ethernet149    149                                    etp19f    19       100000   rs    off     6
-Ethernet150    150                                    etp19g    19       100000   rs    off     7
-Ethernet151    151                                    etp19h    19       100000   rs    off     8
-Ethernet160    160                                    etp21a    21       100000   rs    off     1
-Ethernet161    161                                    etp21b    21       100000   rs    off     2
-Ethernet162    162                                    etp21c    21       100000   rs    off     3
-Ethernet163    163                                    etp21d    21       100000   rs    off     4
-Ethernet164    164                                    etp21e    21       100000   rs    off     5
-Ethernet165    165                                    etp21f    21       100000   rs    off     6
-Ethernet166    166                                    etp21g    21       100000   rs    off     7
-Ethernet167    167                                    etp21h    21       100000   rs    off     8
-Ethernet176    176                                    etp23a    23       100000   rs    off     1
-Ethernet177    177                                    etp23b    23       100000   rs    off     2
-Ethernet178    178                                    etp23c    23       100000   rs    off     3
-Ethernet179    179                                    etp23d    23       100000   rs    off     4
-Ethernet180    180                                    etp23e    23       100000   rs    off     5
-Ethernet181    181                                    etp23f    23       100000   rs    off     6
-Ethernet182    182                                    etp23g    23       100000   rs    off     7
-Ethernet183    183                                    etp23h    23       100000   rs    off     8
-Ethernet192    192                                    etp25a    25       100000   rs    off     1
-Ethernet193    193                                    etp25b    25       100000   rs    off     2
-Ethernet194    194                                    etp25c    25       100000   rs    off     3
-Ethernet195    195                                    etp25d    25       100000   rs    off     4
-Ethernet196    196                                    etp25e    25       100000   rs    off     5
-Ethernet197    197                                    etp25f    25       100000   rs    off     6
-Ethernet198    198                                    etp25g    25       100000   rs    off     7
-Ethernet199    199                                    etp25h    25       100000   rs    off     8
-Ethernet208    208                                    etp27a    27       100000   rs    off     1
-Ethernet209    209                                    etp27b    27       100000   rs    off     2
-Ethernet210    210                                    etp27c    27       100000   rs    off     3
-Ethernet211    211                                    etp27d    27       100000   rs    off     4
-Ethernet212    212                                    etp27e    27       100000   rs    off     5
-Ethernet213    213                                    etp27f    27       100000   rs    off     6
-Ethernet214    214                                    etp27g    27       100000   rs    off     7
-Ethernet215    215                                    etp27h    27       100000   rs    off     8
-Ethernet224    224                                    etp29a    29       100000   rs    off     1
-Ethernet225    225                                    etp29b    29       100000   rs    off     2
-Ethernet226    226                                    etp29c    29       100000   rs    off     3
-Ethernet227    227                                    etp29d    29       100000   rs    off     4
-Ethernet228    228                                    etp29e    29       100000   rs    off     5
-Ethernet229    229                                    etp29f    29       100000   rs    off     6
-Ethernet230    230                                    etp29g    29       100000   rs    off     7
-Ethernet231    231                                    etp29h    29       100000   rs    off     8
-Ethernet240    240                                    etp31a    31       100000   rs    off     1
-Ethernet241    241                                    etp31b    31       100000   rs    off     2
-Ethernet242    242                                    etp31c    31       100000   rs    off     3
-Ethernet243    243                                    etp31d    31       100000   rs    off     4
-Ethernet244    244                                    etp31e    31       100000   rs    off     5
-Ethernet245    245                                    etp31f    31       100000   rs    off     6
-Ethernet246    246                                    etp31g    31       100000   rs    off     7
-Ethernet247    247                                    etp31h    31       100000   rs    off     8
-Ethernet256    256                                    etp33a    33       100000   rs    off     1
-Ethernet257    257                                    etp33b    33       100000   rs    off     2
-Ethernet258    258                                    etp33c    33       100000   rs    off     3
-Ethernet259    259                                    etp33d    33       100000   rs    off     4
-Ethernet260    260                                    etp33e    33       100000   rs    off     5
-Ethernet261    261                                    etp33f    33       100000   rs    off     6
-Ethernet262    262                                    etp33g    33       100000   rs    off     7
-Ethernet263    263                                    etp33h    33       100000   rs    off     8
-Ethernet272    272                                    etp35a    35       100000   rs    off     1
-Ethernet273    273                                    etp35b    35       100000   rs    off     2
-Ethernet274    274                                    etp35c    35       100000   rs    off     3
-Ethernet275    275                                    etp35d    35       100000   rs    off     4
-Ethernet276    276                                    etp35e    35       100000   rs    off     5
-Ethernet277    277                                    etp35f    35       100000   rs    off     6
-Ethernet278    278                                    etp35g    35       100000   rs    off     7
-Ethernet279    279                                    etp35h    35       100000   rs    off     8
-Ethernet288    288                                    etp37a    37       100000   rs    off     1
-Ethernet289    289                                    etp37b    37       100000   rs    off     2
-Ethernet290    290                                    etp37c    37       100000   rs    off     3
-Ethernet291    291                                    etp37d    37       100000   rs    off     4
-Ethernet292    292                                    etp37e    37       100000   rs    off     5
-Ethernet293    293                                    etp37f    37       100000   rs    off     6
-Ethernet294    294                                    etp37g    37       100000   rs    off     7
-Ethernet295    295                                    etp37h    37       100000   rs    off     8
-Ethernet304    304                                    etp39a    39       100000   rs    off     1
-Ethernet305    305                                    etp39b    39       100000   rs    off     2
-Ethernet306    306                                    etp39c    39       100000   rs    off     3
-Ethernet307    307                                    etp39d    39       100000   rs    off     4
-Ethernet308    308                                    etp39e    39       100000   rs    off     5
-Ethernet309    309                                    etp39f    39       100000   rs    off     6
-Ethernet310    310                                    etp39g    39       100000   rs    off     7
-Ethernet311    311                                    etp39h    39       100000   rs    off     8
-Ethernet320    320                                    etp41a    41       100000   rs    off     1
-Ethernet321    321                                    etp41b    41       100000   rs    off     2
-Ethernet322    322                                    etp41c    41       100000   rs    off     3
-Ethernet323    323                                    etp41d    41       100000   rs    off     4
-Ethernet324    324                                    etp41e    41       100000   rs    off     5
-Ethernet325    325                                    etp41f    41       100000   rs    off     6
-Ethernet326    326                                    etp41g    41       100000   rs    off     7
-Ethernet327    327                                    etp41h    41       100000   rs    off     8
-Ethernet336    336                                    etp43a    43       100000   rs    off     1
-Ethernet337    337                                    etp43b    43       100000   rs    off     2
-Ethernet338    338                                    etp43c    43       100000   rs    off     3
-Ethernet339    339                                    etp43d    43       100000   rs    off     4
-Ethernet340    340                                    etp43e    43       100000   rs    off     5
-Ethernet341    341                                    etp43f    43       100000   rs    off     6
-Ethernet342    342                                    etp43g    43       100000   rs    off     7
-Ethernet343    343                                    etp43h    43       100000   rs    off     8
-Ethernet352    352                                    etp45a    45       100000   rs    off     1
-Ethernet353    353                                    etp45b    45       100000   rs    off     2
-Ethernet354    354                                    etp45c    45       100000   rs    off     3
-Ethernet355    355                                    etp45d    45       100000   rs    off     4
-Ethernet356    356                                    etp45e    45       100000   rs    off     5
-Ethernet357    357                                    etp45f    45       100000   rs    off     6
-Ethernet358    358                                    etp45g    45       100000   rs    off     7
-Ethernet359    359                                    etp45h    45       100000   rs    off     8
-Ethernet368    368                                    etp47a    47       100000   rs    off     1
-Ethernet369    369                                    etp47b    47       100000   rs    off     2
-Ethernet370    370                                    etp47c    47       100000   rs    off     3
-Ethernet371    371                                    etp47d    47       100000   rs    off     4
-Ethernet372    372                                    etp47e    47       100000   rs    off     5
-Ethernet373    373                                    etp47f    47       100000   rs    off     6
-Ethernet374    374                                    etp47g    47       100000   rs    off     7
-Ethernet375    375                                    etp47h    47       100000   rs    off     8
-Ethernet384    384                                    etp49a    49       100000   rs    off     1
-Ethernet385    385                                    etp49b    49       100000   rs    off     2
-Ethernet386    386                                    etp49c    49       100000   rs    off     3
-Ethernet387    387                                    etp49d    49       100000   rs    off     4
-Ethernet388    388                                    etp49e    49       100000   rs    off     5
-Ethernet389    389                                    etp49f    49       100000   rs    off     6
-Ethernet390    390                                    etp49g    49       100000   rs    off     7
-Ethernet391    391                                    etp49h    49       100000   rs    off     8
-Ethernet400    400                                    etp51a    51       100000   rs    off     1
-Ethernet401    401                                    etp51b    51       100000   rs    off     2
-Ethernet402    402                                    etp51c    51       100000   rs    off     3
-Ethernet403    403                                    etp51d    51       100000   rs    off     4
-Ethernet404    404                                    etp51e    51       100000   rs    off     5
-Ethernet405    405                                    etp51f    51       100000   rs    off     6
-Ethernet406    406                                    etp51g    51       100000   rs    off     7
-Ethernet407    407                                    etp51h    51       100000   rs    off     8
-Ethernet416    416                                    etp53a    53       100000   rs    off     1
-Ethernet417    417                                    etp53b    53       100000   rs    off     2
-Ethernet418    418                                    etp53c    53       100000   rs    off     3
-Ethernet419    419                                    etp53d    53       100000   rs    off     4
-Ethernet420    420                                    etp53e    53       100000   rs    off     5
-Ethernet421    421                                    etp53f    53       100000   rs    off     6
-Ethernet422    422                                    etp53g    53       100000   rs    off     7
-Ethernet423    423                                    etp53h    53       100000   rs    off     8
-Ethernet432    432                                    etp55a    55       100000   rs    off     1
-Ethernet433    433                                    etp55b    55       100000   rs    off     2
-Ethernet434    434                                    etp55c    55       100000   rs    off     3
-Ethernet435    435                                    etp55d    55       100000   rs    off     4
-Ethernet436    436                                    etp55e    55       100000   rs    off     5
-Ethernet437    437                                    etp55f    55       100000   rs    off     6
-Ethernet438    438                                    etp55g    55       100000   rs    off     7
-Ethernet439    439                                    etp55h    55       100000   rs    off     8
-Ethernet448    448                                    etp57a    57       100000   rs    off     1
-Ethernet449    449                                    etp57b    57       100000   rs    off     2
-Ethernet450    450                                    etp57c    57       100000   rs    off     3
-Ethernet451    451                                    etp57d    57       100000   rs    off     4
-Ethernet452    452                                    etp57e    57       100000   rs    off     5
-Ethernet453    453                                    etp57f    57       100000   rs    off     6
-Ethernet454    454                                    etp57g    57       100000   rs    off     7
-Ethernet455    455                                    etp57h    57       100000   rs    off     8
-Ethernet464    464                                    etp59a    59       100000   rs    off     1
-Ethernet465    465                                    etp59b    59       100000   rs    off     2
-Ethernet466    466                                    etp59c    59       100000   rs    off     3
-Ethernet467    467                                    etp59d    59       100000   rs    off     4
-Ethernet468    468                                    etp59e    59       100000   rs    off     5
-Ethernet469    469                                    etp59f    59       100000   rs    off     6
-Ethernet470    470                                    etp59g    59       100000   rs    off     7
-Ethernet471    471                                    etp59h    59       100000   rs    off     8
-Ethernet480    480                                    etp61a    61       100000   rs    off     1
-Ethernet481    481                                    etp61b    61       100000   rs    off     2
-Ethernet482    482                                    etp61c    61       100000   rs    off     3
-Ethernet483    483                                    etp61d    61       100000   rs    off     4
-Ethernet484    484                                    etp61e    61       100000   rs    off     5
-Ethernet485    485                                    etp61f    61       100000   rs    off     6
-Ethernet486    486                                    etp61g    61       100000   rs    off     7
-Ethernet487    487                                    etp61h    61       100000   rs    off     8
-Ethernet496    496                                    etp63a    63       100000   rs    off     1
-Ethernet497    497                                    etp63b    63       100000   rs    off     2
-Ethernet498    498                                    etp63c    63       100000   rs    off     3
-Ethernet499    499                                    etp63d    63       100000   rs    off     4
-Ethernet500    500                                    etp63e    63       100000   rs    off     5
-Ethernet501    501                                    etp63f    63       100000   rs    off     6
-Ethernet502    502                                    etp63g    63       100000   rs    off     7
-Ethernet503    503                                    etp63h    63       100000   rs    off     8
-Ethernet512    512                                    etp65     65        10000   rs
+# name         lanes                                  alias     index    speed    autoneg subport
+Ethernet0      0                                      etp1a     1        100000   off     1
+Ethernet1      1                                      etp1b     1        100000   off     2
+Ethernet2      2                                      etp1c     1        100000   off     3
+Ethernet3      3                                      etp1d     1        100000   off     4
+Ethernet4      4                                      etp1e     1        100000   off     5
+Ethernet5      5                                      etp1f     1        100000   off     6
+Ethernet6      6                                      etp1g     1        100000   off     7
+Ethernet7      7                                      etp1h     1        100000   off     8
+Ethernet16     16                                     etp3a     3        100000   off     1
+Ethernet17     17                                     etp3b     3        100000   off     2
+Ethernet18     18                                     etp3c     3        100000   off     3
+Ethernet19     19                                     etp3d     3        100000   off     4
+Ethernet20     20                                     etp3e     3        100000   off     5
+Ethernet21     21                                     etp3f     3        100000   off     6
+Ethernet22     22                                     etp3g     3        100000   off     7
+Ethernet23     23                                     etp3h     3        100000   off     8
+Ethernet32     32                                     etp5a     5        100000   off     1
+Ethernet33     33                                     etp5b     5        100000   off     2
+Ethernet34     34                                     etp5c     5        100000   off     3
+Ethernet35     35                                     etp5d     5        100000   off     4
+Ethernet36     36                                     etp5e     5        100000   off     5
+Ethernet37     37                                     etp5f     5        100000   off     6
+Ethernet38     38                                     etp5g     5        100000   off     7
+Ethernet39     39                                     etp5h     5        100000   off     8
+Ethernet48     48                                     etp7a     7        100000   off     1
+Ethernet49     49                                     etp7b     7        100000   off     2
+Ethernet50     50                                     etp7c     7        100000   off     3
+Ethernet51     51                                     etp7d     7        100000   off     4
+Ethernet52     52                                     etp7e     7        100000   off     5
+Ethernet53     53                                     etp7f     7        100000   off     6
+Ethernet54     54                                     etp7g     7        100000   off     7
+Ethernet55     55                                     etp7h     7        100000   off     8
+Ethernet64     64                                     etp9a     9        100000   off     1
+Ethernet65     65                                     etp9b     9        100000   off     2
+Ethernet66     66                                     etp9c     9        100000   off     3
+Ethernet67     67                                     etp9d     9        100000   off     4
+Ethernet68     68                                     etp9e     9        100000   off     5
+Ethernet69     69                                     etp9f     9        100000   off     6
+Ethernet70     70                                     etp9g     9        100000   off     7
+Ethernet71     71                                     etp9h     9        100000   off     8
+Ethernet80     80                                     etp11a    11       100000   off     1
+Ethernet81     81                                     etp11b    11       100000   off     2
+Ethernet82     82                                     etp11c    11       100000   off     3
+Ethernet83     83                                     etp11d    11       100000   off     4
+Ethernet84     84                                     etp11e    11       100000   off     5
+Ethernet85     85                                     etp11f    11       100000   off     6
+Ethernet86     86                                     etp11g    11       100000   off     7
+Ethernet87     87                                     etp11h    11       100000   off     8
+Ethernet96     96                                     etp13a    13       100000   off     1
+Ethernet97     97                                     etp13b    13       100000   off     2
+Ethernet98     98                                     etp13c    13       100000   off     3
+Ethernet99     99                                     etp13d    13       100000   off     4
+Ethernet100    100                                    etp13e    13       100000   off     5
+Ethernet101    101                                    etp13f    13       100000   off     6
+Ethernet102    102                                    etp13g    13       100000   off     7
+Ethernet103    103                                    etp13h    13       100000   off     8
+Ethernet112    112                                    etp15a    15       100000   off     1
+Ethernet113    113                                    etp15b    15       100000   off     2
+Ethernet114    114                                    etp15c    15       100000   off     3
+Ethernet115    115                                    etp15d    15       100000   off     4
+Ethernet116    116                                    etp15e    15       100000   off     5
+Ethernet117    117                                    etp15f    15       100000   off     6
+Ethernet118    118                                    etp15g    15       100000   off     7
+Ethernet119    119                                    etp15h    15       100000   off     8
+Ethernet128    128                                    etp17a    17       100000   off     1
+Ethernet129    129                                    etp17b    17       100000   off     2
+Ethernet130    130                                    etp17c    17       100000   off     3
+Ethernet131    131                                    etp17d    17       100000   off     4
+Ethernet132    132                                    etp17e    17       100000   off     5
+Ethernet133    133                                    etp17f    17       100000   off     6
+Ethernet134    134                                    etp17g    17       100000   off     7
+Ethernet135    135                                    etp17h    17       100000   off     8
+Ethernet144    144                                    etp19a    19       100000   off     1
+Ethernet145    145                                    etp19b    19       100000   off     2
+Ethernet146    146                                    etp19c    19       100000   off     3
+Ethernet147    147                                    etp19d    19       100000   off     4
+Ethernet148    148                                    etp19e    19       100000   off     5
+Ethernet149    149                                    etp19f    19       100000   off     6
+Ethernet150    150                                    etp19g    19       100000   off     7
+Ethernet151    151                                    etp19h    19       100000   off     8
+Ethernet160    160                                    etp21a    21       100000   off     1
+Ethernet161    161                                    etp21b    21       100000   off     2
+Ethernet162    162                                    etp21c    21       100000   off     3
+Ethernet163    163                                    etp21d    21       100000   off     4
+Ethernet164    164                                    etp21e    21       100000   off     5
+Ethernet165    165                                    etp21f    21       100000   off     6
+Ethernet166    166                                    etp21g    21       100000   off     7
+Ethernet167    167                                    etp21h    21       100000   off     8
+Ethernet176    176                                    etp23a    23       100000   off     1
+Ethernet177    177                                    etp23b    23       100000   off     2
+Ethernet178    178                                    etp23c    23       100000   off     3
+Ethernet179    179                                    etp23d    23       100000   off     4
+Ethernet180    180                                    etp23e    23       100000   off     5
+Ethernet181    181                                    etp23f    23       100000   off     6
+Ethernet182    182                                    etp23g    23       100000   off     7
+Ethernet183    183                                    etp23h    23       100000   off     8
+Ethernet192    192                                    etp25a    25       100000   off     1
+Ethernet193    193                                    etp25b    25       100000   off     2
+Ethernet194    194                                    etp25c    25       100000   off     3
+Ethernet195    195                                    etp25d    25       100000   off     4
+Ethernet196    196                                    etp25e    25       100000   off     5
+Ethernet197    197                                    etp25f    25       100000   off     6
+Ethernet198    198                                    etp25g    25       100000   off     7
+Ethernet199    199                                    etp25h    25       100000   off     8
+Ethernet208    208                                    etp27a    27       100000   off     1
+Ethernet209    209                                    etp27b    27       100000   off     2
+Ethernet210    210                                    etp27c    27       100000   off     3
+Ethernet211    211                                    etp27d    27       100000   off     4
+Ethernet212    212                                    etp27e    27       100000   off     5
+Ethernet213    213                                    etp27f    27       100000   off     6
+Ethernet214    214                                    etp27g    27       100000   off     7
+Ethernet215    215                                    etp27h    27       100000   off     8
+Ethernet224    224                                    etp29a    29       100000   off     1
+Ethernet225    225                                    etp29b    29       100000   off     2
+Ethernet226    226                                    etp29c    29       100000   off     3
+Ethernet227    227                                    etp29d    29       100000   off     4
+Ethernet228    228                                    etp29e    29       100000   off     5
+Ethernet229    229                                    etp29f    29       100000   off     6
+Ethernet230    230                                    etp29g    29       100000   off     7
+Ethernet231    231                                    etp29h    29       100000   off     8
+Ethernet240    240                                    etp31a    31       100000   off     1
+Ethernet241    241                                    etp31b    31       100000   off     2
+Ethernet242    242                                    etp31c    31       100000   off     3
+Ethernet243    243                                    etp31d    31       100000   off     4
+Ethernet244    244                                    etp31e    31       100000   off     5
+Ethernet245    245                                    etp31f    31       100000   off     6
+Ethernet246    246                                    etp31g    31       100000   off     7
+Ethernet247    247                                    etp31h    31       100000   off     8
+Ethernet256    256                                    etp33a    33       100000   off     1
+Ethernet257    257                                    etp33b    33       100000   off     2
+Ethernet258    258                                    etp33c    33       100000   off     3
+Ethernet259    259                                    etp33d    33       100000   off     4
+Ethernet260    260                                    etp33e    33       100000   off     5
+Ethernet261    261                                    etp33f    33       100000   off     6
+Ethernet262    262                                    etp33g    33       100000   off     7
+Ethernet263    263                                    etp33h    33       100000   off     8
+Ethernet272    272                                    etp35a    35       100000   off     1
+Ethernet273    273                                    etp35b    35       100000   off     2
+Ethernet274    274                                    etp35c    35       100000   off     3
+Ethernet275    275                                    etp35d    35       100000   off     4
+Ethernet276    276                                    etp35e    35       100000   off     5
+Ethernet277    277                                    etp35f    35       100000   off     6
+Ethernet278    278                                    etp35g    35       100000   off     7
+Ethernet279    279                                    etp35h    35       100000   off     8
+Ethernet288    288                                    etp37a    37       100000   off     1
+Ethernet289    289                                    etp37b    37       100000   off     2
+Ethernet290    290                                    etp37c    37       100000   off     3
+Ethernet291    291                                    etp37d    37       100000   off     4
+Ethernet292    292                                    etp37e    37       100000   off     5
+Ethernet293    293                                    etp37f    37       100000   off     6
+Ethernet294    294                                    etp37g    37       100000   off     7
+Ethernet295    295                                    etp37h    37       100000   off     8
+Ethernet304    304                                    etp39a    39       100000   off     1
+Ethernet305    305                                    etp39b    39       100000   off     2
+Ethernet306    306                                    etp39c    39       100000   off     3
+Ethernet307    307                                    etp39d    39       100000   off     4
+Ethernet308    308                                    etp39e    39       100000   off     5
+Ethernet309    309                                    etp39f    39       100000   off     6
+Ethernet310    310                                    etp39g    39       100000   off     7
+Ethernet311    311                                    etp39h    39       100000   off     8
+Ethernet320    320                                    etp41a    41       100000   off     1
+Ethernet321    321                                    etp41b    41       100000   off     2
+Ethernet322    322                                    etp41c    41       100000   off     3
+Ethernet323    323                                    etp41d    41       100000   off     4
+Ethernet324    324                                    etp41e    41       100000   off     5
+Ethernet325    325                                    etp41f    41       100000   off     6
+Ethernet326    326                                    etp41g    41       100000   off     7
+Ethernet327    327                                    etp41h    41       100000   off     8
+Ethernet336    336                                    etp43a    43       100000   off     1
+Ethernet337    337                                    etp43b    43       100000   off     2
+Ethernet338    338                                    etp43c    43       100000   off     3
+Ethernet339    339                                    etp43d    43       100000   off     4
+Ethernet340    340                                    etp43e    43       100000   off     5
+Ethernet341    341                                    etp43f    43       100000   off     6
+Ethernet342    342                                    etp43g    43       100000   off     7
+Ethernet343    343                                    etp43h    43       100000   off     8
+Ethernet352    352                                    etp45a    45       100000   off     1
+Ethernet353    353                                    etp45b    45       100000   off     2
+Ethernet354    354                                    etp45c    45       100000   off     3
+Ethernet355    355                                    etp45d    45       100000   off     4
+Ethernet356    356                                    etp45e    45       100000   off     5
+Ethernet357    357                                    etp45f    45       100000   off     6
+Ethernet358    358                                    etp45g    45       100000   off     7
+Ethernet359    359                                    etp45h    45       100000   off     8
+Ethernet368    368                                    etp47a    47       100000   off     1
+Ethernet369    369                                    etp47b    47       100000   off     2
+Ethernet370    370                                    etp47c    47       100000   off     3
+Ethernet371    371                                    etp47d    47       100000   off     4
+Ethernet372    372                                    etp47e    47       100000   off     5
+Ethernet373    373                                    etp47f    47       100000   off     6
+Ethernet374    374                                    etp47g    47       100000   off     7
+Ethernet375    375                                    etp47h    47       100000   off     8
+Ethernet384    384                                    etp49a    49       100000   off     1
+Ethernet385    385                                    etp49b    49       100000   off     2
+Ethernet386    386                                    etp49c    49       100000   off     3
+Ethernet387    387                                    etp49d    49       100000   off     4
+Ethernet388    388                                    etp49e    49       100000   off     5
+Ethernet389    389                                    etp49f    49       100000   off     6
+Ethernet390    390                                    etp49g    49       100000   off     7
+Ethernet391    391                                    etp49h    49       100000   off     8
+Ethernet400    400                                    etp51a    51       100000   off     1
+Ethernet401    401                                    etp51b    51       100000   off     2
+Ethernet402    402                                    etp51c    51       100000   off     3
+Ethernet403    403                                    etp51d    51       100000   off     4
+Ethernet404    404                                    etp51e    51       100000   off     5
+Ethernet405    405                                    etp51f    51       100000   off     6
+Ethernet406    406                                    etp51g    51       100000   off     7
+Ethernet407    407                                    etp51h    51       100000   off     8
+Ethernet416    416                                    etp53a    53       100000   off     1
+Ethernet417    417                                    etp53b    53       100000   off     2
+Ethernet418    418                                    etp53c    53       100000   off     3
+Ethernet419    419                                    etp53d    53       100000   off     4
+Ethernet420    420                                    etp53e    53       100000   off     5
+Ethernet421    421                                    etp53f    53       100000   off     6
+Ethernet422    422                                    etp53g    53       100000   off     7
+Ethernet423    423                                    etp53h    53       100000   off     8
+Ethernet432    432                                    etp55a    55       100000   off     1
+Ethernet433    433                                    etp55b    55       100000   off     2
+Ethernet434    434                                    etp55c    55       100000   off     3
+Ethernet435    435                                    etp55d    55       100000   off     4
+Ethernet436    436                                    etp55e    55       100000   off     5
+Ethernet437    437                                    etp55f    55       100000   off     6
+Ethernet438    438                                    etp55g    55       100000   off     7
+Ethernet439    439                                    etp55h    55       100000   off     8
+Ethernet448    448                                    etp57a    57       100000   off     1
+Ethernet449    449                                    etp57b    57       100000   off     2
+Ethernet450    450                                    etp57c    57       100000   off     3
+Ethernet451    451                                    etp57d    57       100000   off     4
+Ethernet452    452                                    etp57e    57       100000   off     5
+Ethernet453    453                                    etp57f    57       100000   off     6
+Ethernet454    454                                    etp57g    57       100000   off     7
+Ethernet455    455                                    etp57h    57       100000   off     8
+Ethernet464    464                                    etp59a    59       100000   off     1
+Ethernet465    465                                    etp59b    59       100000   off     2
+Ethernet466    466                                    etp59c    59       100000   off     3
+Ethernet467    467                                    etp59d    59       100000   off     4
+Ethernet468    468                                    etp59e    59       100000   off     5
+Ethernet469    469                                    etp59f    59       100000   off     6
+Ethernet470    470                                    etp59g    59       100000   off     7
+Ethernet471    471                                    etp59h    59       100000   off     8
+Ethernet480    480                                    etp61a    61       100000   off     1
+Ethernet481    481                                    etp61b    61       100000   off     2
+Ethernet482    482                                    etp61c    61       100000   off     3
+Ethernet483    483                                    etp61d    61       100000   off     4
+Ethernet484    484                                    etp61e    61       100000   off     5
+Ethernet485    485                                    etp61f    61       100000   off     6
+Ethernet486    486                                    etp61g    61       100000   off     7
+Ethernet487    487                                    etp61h    61       100000   off     8
+Ethernet496    496                                    etp63a    63       100000   off     1
+Ethernet497    497                                    etp63b    63       100000   off     2
+Ethernet498    498                                    etp63c    63       100000   off     3
+Ethernet499    499                                    etp63d    63       100000   off     4
+Ethernet500    500                                    etp63e    63       100000   off     5
+Ethernet501    501                                    etp63f    63       100000   off     6
+Ethernet502    502                                    etp63g    63       100000   off     7
+Ethernet503    503                                    etp63h    63       100000   off     8
+Ethernet512    512                                    etp65     65        10000

--- a/device/mellanox/x86_64-nvidia_sn5600-r0/Mellanox-SN5600-O128/port_config.ini
+++ b/device/mellanox/x86_64-nvidia_sn5600-r0/Mellanox-SN5600-O128/port_config.ini
@@ -15,133 +15,133 @@
 ## limitations under the License.
 ##
 
-# name         lanes                                  alias     index    speed    fec
-Ethernet0      0,1,2,3                                etp1a     1        400000   rs
-Ethernet4      4,5,6,7                                etp1b     1        400000   rs
-Ethernet8      8,9,10,11                              etp2a     2        400000   rs
-Ethernet12     12,13,14,15                            etp2b     2        400000   rs
-Ethernet16     16,17,18,19                            etp3a     3        400000   rs
-Ethernet20     20,21,22,23                            etp3b     3        400000   rs
-Ethernet24     24,25,26,27                            etp4a     4        400000   rs
-Ethernet28     28,29,30,31                            etp4b     4        400000   rs
-Ethernet32     32,33,34,35                            etp5a     5        400000   rs
-Ethernet36     36,37,38,39                            etp5b     5        400000   rs
-Ethernet40     40,41,42,43                            etp6a     6        400000   rs
-Ethernet44     44,45,46,47                            etp6b     6        400000   rs
-Ethernet48     48,49,50,51                            etp7a     7        400000   rs
-Ethernet52     52,53,54,55                            etp7b     7        400000   rs
-Ethernet56     56,57,58,59                            etp8a     8        400000   rs
-Ethernet60     60,61,62,63                            etp8b     8        400000   rs
-Ethernet64     64,65,66,67                            etp9a     9        400000   rs
-Ethernet68     68,69,70,71                            etp9b     9        400000   rs
-Ethernet72     72,73,74,75                            etp10a    10       400000   rs
-Ethernet76     76,77,78,79                            etp10b    10       400000   rs
-Ethernet80     80,81,82,83                            etp11a    11       400000   rs
-Ethernet84     84,85,86,87                            etp11b    11       400000   rs
-Ethernet88     88,89,90,91                            etp12a    12       400000   rs
-Ethernet92     92,93,94,95                            etp12b    12       400000   rs
-Ethernet96     96,97,98,99                            etp13a    13       400000   rs
-Ethernet100    100,101,102,103                        etp13b    13       400000   rs
-Ethernet104    104,105,106,107                        etp14a    14       400000   rs
-Ethernet108    108,109,110,111                        etp14b    14       400000   rs
-Ethernet112    112,113,114,115                        etp15a    15       400000   rs
-Ethernet116    116,117,118,119                        etp15b    15       400000   rs
-Ethernet120    120,121,122,123                        etp16a    16       400000   rs
-Ethernet124    124,125,126,127                        etp16b    16       400000   rs
-Ethernet128    128,129,130,131                        etp17a    17       400000   rs
-Ethernet132    132,133,134,135                        etp17b    17       400000   rs
-Ethernet136    136,137,138,139                        etp18a    18       400000   rs
-Ethernet140    140,141,142,143                        etp18b    18       400000   rs
-Ethernet144    144,145,146,147                        etp19a    19       400000   rs
-Ethernet148    148,149,150,151                        etp19b    19       400000   rs
-Ethernet152    152,153,154,155                        etp20a    20       400000   rs
-Ethernet156    156,157,158,159                        etp20b    20       400000   rs
-Ethernet160    160,161,162,163                        etp21a    21       400000   rs
-Ethernet164    164,165,166,167                        etp21b    21       400000   rs
-Ethernet168    168,169,170,171                        etp22a    22       400000   rs
-Ethernet172    172,173,174,175                        etp22b    22       400000   rs
-Ethernet176    176,177,178,179                        etp23a    23       400000   rs
-Ethernet180    180,181,182,183                        etp23b    23       400000   rs
-Ethernet184    184,185,186,187                        etp24a    24       400000   rs
-Ethernet188    188,189,190,191                        etp24b    24       400000   rs
-Ethernet192    192,193,194,195                        etp25a    25       400000   rs
-Ethernet196    196,197,198,199                        etp25b    25       400000   rs
-Ethernet200    200,201,202,203                        etp26a    26       400000   rs
-Ethernet204    204,205,206,207                        etp26b    26       400000   rs
-Ethernet208    208,209,210,211                        etp27a    27       400000   rs
-Ethernet212    212,213,214,215                        etp27b    27       400000   rs
-Ethernet216    216,217,218,219                        etp28a    28       400000   rs
-Ethernet220    220,221,222,223                        etp28b    28       400000   rs
-Ethernet224    224,225,226,227                        etp29a    29       400000   rs
-Ethernet228    228,229,230,231                        etp29b    29       400000   rs
-Ethernet232    232,233,234,235                        etp30a    30       400000   rs
-Ethernet236    236,237,238,239                        etp30b    30       400000   rs
-Ethernet240    240,241,242,243                        etp31a    31       400000   rs
-Ethernet244    244,245,246,247                        etp31b    31       400000   rs
-Ethernet248    248,249,250,251                        etp32a    32       400000   rs
-Ethernet252    252,253,254,255                        etp32b    32       400000   rs
-Ethernet256    256,257,258,259                        etp33a    33       400000   rs
-Ethernet260    260,261,262,263                        etp33b    33       400000   rs
-Ethernet264    264,265,266,267                        etp34a    34       400000   rs
-Ethernet268    268,269,270,271                        etp34b    34       400000   rs
-Ethernet272    272,273,274,275                        etp35a    35       400000   rs
-Ethernet276    276,277,278,279                        etp35b    35       400000   rs
-Ethernet280    280,281,282,283                        etp36a    36       400000   rs
-Ethernet284    284,285,286,287                        etp36b    36       400000   rs
-Ethernet288    288,289,290,291                        etp37a    37       400000   rs
-Ethernet292    292,293,294,295                        etp37b    37       400000   rs
-Ethernet296    296,297,298,299                        etp38a    38       400000   rs
-Ethernet300    300,301,302,303                        etp38b    38       400000   rs
-Ethernet304    304,305,306,307                        etp39a    39       400000   rs
-Ethernet308    308,309,310,311                        etp39b    39       400000   rs
-Ethernet312    312,313,314,315                        etp40a    40       400000   rs
-Ethernet316    316,317,318,319                        etp40b    40       400000   rs
-Ethernet320    320,321,322,323                        etp41a    41       400000   rs
-Ethernet324    324,325,326,327                        etp41b    41       400000   rs
-Ethernet328    328,329,330,331                        etp42a    42       400000   rs
-Ethernet332    332,333,334,335                        etp42b    42       400000   rs
-Ethernet336    336,337,338,339                        etp43a    43       400000   rs
-Ethernet340    340,341,342,343                        etp43b    43       400000   rs
-Ethernet344    344,345,346,347                        etp44a    44       400000   rs
-Ethernet348    348,349,350,351                        etp44b    44       400000   rs
-Ethernet352    352,353,354,355                        etp45a    45       400000   rs
-Ethernet356    356,357,358,359                        etp45b    45       400000   rs
-Ethernet360    360,361,362,363                        etp46a    46       400000   rs
-Ethernet364    364,365,366,367                        etp46b    46       400000   rs
-Ethernet368    368,369,370,371                        etp47a    47       400000   rs
-Ethernet372    372,373,374,375                        etp47b    47       400000   rs
-Ethernet376    376,377,378,379                        etp48a    48       400000   rs
-Ethernet380    380,381,382,383                        etp48b    48       400000   rs
-Ethernet384    384,385,386,387                        etp49a    49       400000   rs
-Ethernet388    388,389,390,391                        etp49b    49       400000   rs
-Ethernet392    392,393,394,395                        etp50a    50       400000   rs
-Ethernet396    396,397,398,399                        etp50b    50       400000   rs
-Ethernet400    400,401,402,403                        etp51a    51       400000   rs
-Ethernet404    404,405,406,407                        etp51b    51       400000   rs
-Ethernet408    408,409,410,411                        etp52a    52       400000   rs
-Ethernet412    412,413,414,415                        etp52b    52       400000   rs
-Ethernet416    416,417,418,419                        etp53a    53       400000   rs
-Ethernet420    420,421,422,423                        etp53b    53       400000   rs
-Ethernet424    424,425,426,427                        etp54a    54       400000   rs
-Ethernet428    428,429,430,431                        etp54b    54       400000   rs
-Ethernet432    432,433,434,435                        etp55a    55       400000   rs
-Ethernet436    436,437,438,439                        etp55b    55       400000   rs
-Ethernet440    440,441,442,443                        etp56a    56       400000   rs
-Ethernet444    444,445,446,447                        etp56b    56       400000   rs
-Ethernet448    448,449,450,451                        etp57a    57       400000   rs
-Ethernet452    452,453,454,455                        etp57b    57       400000   rs
-Ethernet456    456,457,458,459                        etp58a    58       400000   rs
-Ethernet460    460,461,462,463                        etp58b    58       400000   rs
-Ethernet464    464,465,466,467                        etp59a    59       400000   rs
-Ethernet468    468,469,470,471                        etp59b    59       400000   rs
-Ethernet472    472,473,474,475                        etp60a    60       400000   rs
-Ethernet476    476,477,478,479                        etp60b    60       400000   rs
-Ethernet480    480,481,482,483                        etp61a    61       400000   rs
-Ethernet484    484,485,486,487                        etp61b    61       400000   rs
-Ethernet488    488,489,490,491                        etp62a    62       400000   rs
-Ethernet492    492,493,494,495                        etp62b    62       400000   rs
-Ethernet496    496,497,498,499                        etp63a    63       400000   rs
-Ethernet500    500,501,502,503                        etp63b    63       400000   rs
-Ethernet504    504,505,506,507                        etp64a    64       400000   rs
-Ethernet508    508,509,510,511                        etp64b    64       400000   rs
+# name         lanes                                  alias     index    speed 
+Ethernet0      0,1,2,3                                etp1a     1        400000
+Ethernet4      4,5,6,7                                etp1b     1        400000
+Ethernet8      8,9,10,11                              etp2a     2        400000
+Ethernet12     12,13,14,15                            etp2b     2        400000
+Ethernet16     16,17,18,19                            etp3a     3        400000
+Ethernet20     20,21,22,23                            etp3b     3        400000
+Ethernet24     24,25,26,27                            etp4a     4        400000
+Ethernet28     28,29,30,31                            etp4b     4        400000
+Ethernet32     32,33,34,35                            etp5a     5        400000
+Ethernet36     36,37,38,39                            etp5b     5        400000
+Ethernet40     40,41,42,43                            etp6a     6        400000
+Ethernet44     44,45,46,47                            etp6b     6        400000
+Ethernet48     48,49,50,51                            etp7a     7        400000
+Ethernet52     52,53,54,55                            etp7b     7        400000
+Ethernet56     56,57,58,59                            etp8a     8        400000
+Ethernet60     60,61,62,63                            etp8b     8        400000
+Ethernet64     64,65,66,67                            etp9a     9        400000
+Ethernet68     68,69,70,71                            etp9b     9        400000
+Ethernet72     72,73,74,75                            etp10a    10       400000
+Ethernet76     76,77,78,79                            etp10b    10       400000
+Ethernet80     80,81,82,83                            etp11a    11       400000
+Ethernet84     84,85,86,87                            etp11b    11       400000
+Ethernet88     88,89,90,91                            etp12a    12       400000
+Ethernet92     92,93,94,95                            etp12b    12       400000
+Ethernet96     96,97,98,99                            etp13a    13       400000
+Ethernet100    100,101,102,103                        etp13b    13       400000
+Ethernet104    104,105,106,107                        etp14a    14       400000
+Ethernet108    108,109,110,111                        etp14b    14       400000
+Ethernet112    112,113,114,115                        etp15a    15       400000
+Ethernet116    116,117,118,119                        etp15b    15       400000
+Ethernet120    120,121,122,123                        etp16a    16       400000
+Ethernet124    124,125,126,127                        etp16b    16       400000
+Ethernet128    128,129,130,131                        etp17a    17       400000
+Ethernet132    132,133,134,135                        etp17b    17       400000
+Ethernet136    136,137,138,139                        etp18a    18       400000
+Ethernet140    140,141,142,143                        etp18b    18       400000
+Ethernet144    144,145,146,147                        etp19a    19       400000
+Ethernet148    148,149,150,151                        etp19b    19       400000
+Ethernet152    152,153,154,155                        etp20a    20       400000
+Ethernet156    156,157,158,159                        etp20b    20       400000
+Ethernet160    160,161,162,163                        etp21a    21       400000
+Ethernet164    164,165,166,167                        etp21b    21       400000
+Ethernet168    168,169,170,171                        etp22a    22       400000
+Ethernet172    172,173,174,175                        etp22b    22       400000
+Ethernet176    176,177,178,179                        etp23a    23       400000
+Ethernet180    180,181,182,183                        etp23b    23       400000
+Ethernet184    184,185,186,187                        etp24a    24       400000
+Ethernet188    188,189,190,191                        etp24b    24       400000
+Ethernet192    192,193,194,195                        etp25a    25       400000
+Ethernet196    196,197,198,199                        etp25b    25       400000
+Ethernet200    200,201,202,203                        etp26a    26       400000
+Ethernet204    204,205,206,207                        etp26b    26       400000
+Ethernet208    208,209,210,211                        etp27a    27       400000
+Ethernet212    212,213,214,215                        etp27b    27       400000
+Ethernet216    216,217,218,219                        etp28a    28       400000
+Ethernet220    220,221,222,223                        etp28b    28       400000
+Ethernet224    224,225,226,227                        etp29a    29       400000
+Ethernet228    228,229,230,231                        etp29b    29       400000
+Ethernet232    232,233,234,235                        etp30a    30       400000
+Ethernet236    236,237,238,239                        etp30b    30       400000
+Ethernet240    240,241,242,243                        etp31a    31       400000
+Ethernet244    244,245,246,247                        etp31b    31       400000
+Ethernet248    248,249,250,251                        etp32a    32       400000
+Ethernet252    252,253,254,255                        etp32b    32       400000
+Ethernet256    256,257,258,259                        etp33a    33       400000
+Ethernet260    260,261,262,263                        etp33b    33       400000
+Ethernet264    264,265,266,267                        etp34a    34       400000
+Ethernet268    268,269,270,271                        etp34b    34       400000
+Ethernet272    272,273,274,275                        etp35a    35       400000
+Ethernet276    276,277,278,279                        etp35b    35       400000
+Ethernet280    280,281,282,283                        etp36a    36       400000
+Ethernet284    284,285,286,287                        etp36b    36       400000
+Ethernet288    288,289,290,291                        etp37a    37       400000
+Ethernet292    292,293,294,295                        etp37b    37       400000
+Ethernet296    296,297,298,299                        etp38a    38       400000
+Ethernet300    300,301,302,303                        etp38b    38       400000
+Ethernet304    304,305,306,307                        etp39a    39       400000
+Ethernet308    308,309,310,311                        etp39b    39       400000
+Ethernet312    312,313,314,315                        etp40a    40       400000
+Ethernet316    316,317,318,319                        etp40b    40       400000
+Ethernet320    320,321,322,323                        etp41a    41       400000
+Ethernet324    324,325,326,327                        etp41b    41       400000
+Ethernet328    328,329,330,331                        etp42a    42       400000
+Ethernet332    332,333,334,335                        etp42b    42       400000
+Ethernet336    336,337,338,339                        etp43a    43       400000
+Ethernet340    340,341,342,343                        etp43b    43       400000
+Ethernet344    344,345,346,347                        etp44a    44       400000
+Ethernet348    348,349,350,351                        etp44b    44       400000
+Ethernet352    352,353,354,355                        etp45a    45       400000
+Ethernet356    356,357,358,359                        etp45b    45       400000
+Ethernet360    360,361,362,363                        etp46a    46       400000
+Ethernet364    364,365,366,367                        etp46b    46       400000
+Ethernet368    368,369,370,371                        etp47a    47       400000
+Ethernet372    372,373,374,375                        etp47b    47       400000
+Ethernet376    376,377,378,379                        etp48a    48       400000
+Ethernet380    380,381,382,383                        etp48b    48       400000
+Ethernet384    384,385,386,387                        etp49a    49       400000
+Ethernet388    388,389,390,391                        etp49b    49       400000
+Ethernet392    392,393,394,395                        etp50a    50       400000
+Ethernet396    396,397,398,399                        etp50b    50       400000
+Ethernet400    400,401,402,403                        etp51a    51       400000
+Ethernet404    404,405,406,407                        etp51b    51       400000
+Ethernet408    408,409,410,411                        etp52a    52       400000
+Ethernet412    412,413,414,415                        etp52b    52       400000
+Ethernet416    416,417,418,419                        etp53a    53       400000
+Ethernet420    420,421,422,423                        etp53b    53       400000
+Ethernet424    424,425,426,427                        etp54a    54       400000
+Ethernet428    428,429,430,431                        etp54b    54       400000
+Ethernet432    432,433,434,435                        etp55a    55       400000
+Ethernet436    436,437,438,439                        etp55b    55       400000
+Ethernet440    440,441,442,443                        etp56a    56       400000
+Ethernet444    444,445,446,447                        etp56b    56       400000
+Ethernet448    448,449,450,451                        etp57a    57       400000
+Ethernet452    452,453,454,455                        etp57b    57       400000
+Ethernet456    456,457,458,459                        etp58a    58       400000
+Ethernet460    460,461,462,463                        etp58b    58       400000
+Ethernet464    464,465,466,467                        etp59a    59       400000
+Ethernet468    468,469,470,471                        etp59b    59       400000
+Ethernet472    472,473,474,475                        etp60a    60       400000
+Ethernet476    476,477,478,479                        etp60b    60       400000
+Ethernet480    480,481,482,483                        etp61a    61       400000
+Ethernet484    484,485,486,487                        etp61b    61       400000
+Ethernet488    488,489,490,491                        etp62a    62       400000
+Ethernet492    492,493,494,495                        etp62b    62       400000
+Ethernet496    496,497,498,499                        etp63a    63       400000
+Ethernet500    500,501,502,503                        etp63b    63       400000
+Ethernet504    504,505,506,507                        etp64a    64       400000
+Ethernet508    508,509,510,511                        etp64b    64       400000
 Ethernet512    512                                    etp65     65       25000

--- a/device/mellanox/x86_64-nvidia_sn5600-r0/Mellanox-SN5600-O128/port_config.ini
+++ b/device/mellanox/x86_64-nvidia_sn5600-r0/Mellanox-SN5600-O128/port_config.ini
@@ -1,5 +1,6 @@
 ##
-## Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES.
+## SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
+## Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 ## Apache-2.0
 ##
 ## Licensed under the Apache License, Version 2.0 (the "License");

--- a/device/mellanox/x86_64-nvidia_sn5600-r0/Mellanox-SN5600-V256/port_config.ini
+++ b/device/mellanox/x86_64-nvidia_sn5600-r0/Mellanox-SN5600-V256/port_config.ini
@@ -15,261 +15,261 @@
 ## limitations under the License.
 ##
 
-# name         lanes                                  alias     index    speed    fec
-Ethernet0      0,1                                    etp1a     1        200000   rs
-Ethernet2      2,3                                    etp1b     1        200000   rs
-Ethernet4      4,5                                    etp1c     1        200000   rs
-Ethernet6      6,7                                    etp1d     1        200000   rs
-Ethernet8      8,9                                    etp2a     2        200000   rs
-Ethernet10     10,11                                  etp2b     2        200000   rs
-Ethernet12     12,13                                  etp2c     2        200000   rs
-Ethernet14     14,15                                  etp2d     2        200000   rs
-Ethernet16     16,17                                  etp3a     3        200000   rs
-Ethernet18     18,19                                  etp3b     3        200000   rs
-Ethernet20     20,21                                  etp3c     3        200000   rs
-Ethernet22     22,23                                  etp3d     3        200000   rs
-Ethernet24     24,25                                  etp4a     4        200000   rs
-Ethernet26     26,27                                  etp4b     4        200000   rs
-Ethernet28     28,29                                  etp4c     4        200000   rs
-Ethernet30     30,31                                  etp4d     4        200000   rs
-Ethernet32     32,33                                  etp5a     5        200000   rs
-Ethernet34     34,35                                  etp5b     5        200000   rs
-Ethernet36     36,37                                  etp5c     5        200000   rs
-Ethernet38     38,39                                  etp5d     5        200000   rs
-Ethernet40     40,41                                  etp6a     6        200000   rs
-Ethernet42     42,43                                  etp6b     6        200000   rs
-Ethernet44     44,45                                  etp6c     6        200000   rs
-Ethernet46     46,47                                  etp6d     6        200000   rs
-Ethernet48     48,49                                  etp7a     7        200000   rs
-Ethernet50     50,51                                  etp7b     7        200000   rs
-Ethernet52     52,53                                  etp7c     7        200000   rs
-Ethernet54     54,55                                  etp7d     7        200000   rs
-Ethernet56     56,57                                  etp8a     8        200000   rs
-Ethernet58     58,59                                  etp8b     8        200000   rs
-Ethernet60     60,61                                  etp8c     8        200000   rs
-Ethernet62     62,63                                  etp8d     8        200000   rs
-Ethernet64     64,65                                  etp9a     9        200000   rs
-Ethernet66     66,67                                  etp9b     9        200000   rs
-Ethernet68     68,69                                  etp9c     9        200000   rs
-Ethernet70     70,71                                  etp9d     9        200000   rs
-Ethernet72     72,73                                  etp10a    10       200000   rs
-Ethernet74     74,75                                  etp10b    10       200000   rs
-Ethernet76     76,77                                  etp10c    10       200000   rs
-Ethernet78     78,79                                  etp10d    10       200000   rs
-Ethernet80     80,81                                  etp11a    11       200000   rs
-Ethernet82     82,83                                  etp11b    11       200000   rs
-Ethernet84     84,85                                  etp11c    11       200000   rs
-Ethernet86     86,87                                  etp11d    11       200000   rs
-Ethernet88     88,89                                  etp12a    12       200000   rs
-Ethernet90     90,91                                  etp12b    12       200000   rs
-Ethernet92     92,93                                  etp12c    12       200000   rs
-Ethernet94     94,95                                  etp12d    12       200000   rs
-Ethernet96     96,97                                  etp13a    13       200000   rs
-Ethernet98     98,99                                  etp13b    13       200000   rs
-Ethernet100    100,101                                etp13c    13       200000   rs
-Ethernet102    102,103                                etp13d    13       200000   rs
-Ethernet104    104,105                                etp14a    14       200000   rs
-Ethernet106    106,107                                etp14b    14       200000   rs
-Ethernet108    108,109                                etp14c    14       200000   rs
-Ethernet110    110,111                                etp14d    14       200000   rs
-Ethernet112    112,113                                etp15a    15       200000   rs
-Ethernet114    114,115                                etp15b    15       200000   rs
-Ethernet116    116,117                                etp15c    15       200000   rs
-Ethernet118    118,119                                etp15d    15       200000   rs
-Ethernet120    120,121                                etp16a    16       200000   rs
-Ethernet122    122,123                                etp16b    16       200000   rs
-Ethernet124    124,125                                etp16c    16       200000   rs
-Ethernet126    126,127                                etp16d    16       200000   rs
-Ethernet128    128,129                                etp17a    17       200000   rs
-Ethernet130    130,131                                etp17b    17       200000   rs
-Ethernet132    132,133                                etp17c    17       200000   rs
-Ethernet134    134,135                                etp17d    17       200000   rs
-Ethernet136    136,137                                etp18a    18       200000   rs
-Ethernet138    138,139                                etp18b    18       200000   rs
-Ethernet140    140,141                                etp18c    18       200000   rs
-Ethernet142    142,143                                etp18d    18       200000   rs
-Ethernet144    144,145                                etp19a    19       200000   rs
-Ethernet146    146,147                                etp19b    19       200000   rs
-Ethernet148    148,149                                etp19c    19       200000   rs
-Ethernet150    150,151                                etp19d    19       200000   rs
-Ethernet152    152,153                                etp20a    20       200000   rs
-Ethernet154    154,155                                etp20b    20       200000   rs
-Ethernet156    156,157                                etp20c    20       200000   rs
-Ethernet158    158,159                                etp20d    20       200000   rs
-Ethernet160    160,161                                etp21a    21       200000   rs
-Ethernet162    162,163                                etp21b    21       200000   rs
-Ethernet164    164,165                                etp21c    21       200000   rs
-Ethernet166    166,167                                etp21d    21       200000   rs
-Ethernet168    168,169                                etp22a    22       200000   rs
-Ethernet170    170,171                                etp22b    22       200000   rs
-Ethernet172    172,173                                etp22c    22       200000   rs
-Ethernet174    174,175                                etp22d    22       200000   rs
-Ethernet176    176,177                                etp23a    23       200000   rs
-Ethernet178    178,179                                etp23b    23       200000   rs
-Ethernet180    180,181                                etp23c    23       200000   rs
-Ethernet182    182,183                                etp23d    23       200000   rs
-Ethernet184    184,185                                etp24a    24       200000   rs
-Ethernet186    186,187                                etp24b    24       200000   rs
-Ethernet188    188,189                                etp24c    24       200000   rs
-Ethernet190    190,191                                etp24d    24       200000   rs
-Ethernet192    192,193                                etp25a    25       200000   rs
-Ethernet194    194,195                                etp25b    25       200000   rs
-Ethernet196    196,197                                etp25c    25       200000   rs
-Ethernet198    198,199                                etp25d    25       200000   rs
-Ethernet200    200,201                                etp26a    26       200000   rs
-Ethernet202    202,203                                etp26b    26       200000   rs
-Ethernet204    204,205                                etp26c    26       200000   rs
-Ethernet206    206,207                                etp26d    26       200000   rs
-Ethernet208    208,209                                etp27a    27       200000   rs
-Ethernet210    210,211                                etp27b    27       200000   rs
-Ethernet212    212,213                                etp27c    27       200000   rs
-Ethernet214    214,215                                etp27d    27       200000   rs
-Ethernet216    216,217                                etp28a    28       200000   rs
-Ethernet218    218,219                                etp28b    28       200000   rs
-Ethernet220    220,221                                etp28c    28       200000   rs
-Ethernet222    222,223                                etp28d    28       200000   rs
-Ethernet224    224,225                                etp29a    29       200000   rs
-Ethernet226    226,227                                etp29b    29       200000   rs
-Ethernet228    228,229                                etp29c    29       200000   rs
-Ethernet230    230,231                                etp29d    29       200000   rs
-Ethernet232    232,233                                etp30a    30       200000   rs
-Ethernet234    234,235                                etp30b    30       200000   rs
-Ethernet236    236,237                                etp30c    30       200000   rs
-Ethernet238    238,239                                etp30d    30       200000   rs
-Ethernet240    240,241                                etp31a    31       200000   rs
-Ethernet242    242,243                                etp31b    31       200000   rs
-Ethernet244    244,245                                etp31c    31       200000   rs
-Ethernet246    246,247                                etp31d    31       200000   rs
-Ethernet248    248,249                                etp32a    32       200000   rs
-Ethernet250    250,251                                etp32b    32       200000   rs
-Ethernet252    252,253                                etp32c    32       200000   rs
-Ethernet254    254,255                                etp32d    32       200000   rs
-Ethernet256    256,257                                etp33a    33       200000   rs
-Ethernet258    258,259                                etp33b    33       200000   rs
-Ethernet260    260,261                                etp33c    33       200000   rs
-Ethernet262    262,263                                etp33d    33       200000   rs
-Ethernet264    264,265                                etp34a    34       200000   rs
-Ethernet266    266,267                                etp34b    34       200000   rs
-Ethernet268    268,269                                etp34c    34       200000   rs
-Ethernet270    270,271                                etp34d    34       200000   rs
-Ethernet272    272,273                                etp35a    35       200000   rs
-Ethernet274    274,275                                etp35b    35       200000   rs
-Ethernet276    276,277                                etp35c    35       200000   rs
-Ethernet278    278,279                                etp35d    35       200000   rs
-Ethernet280    280,281                                etp36a    36       200000   rs
-Ethernet282    282,283                                etp36b    36       200000   rs
-Ethernet284    284,285                                etp36c    36       200000   rs
-Ethernet286    286,287                                etp36d    36       200000   rs
-Ethernet288    288,289                                etp37a    37       200000   rs
-Ethernet290    290,291                                etp37b    37       200000   rs
-Ethernet292    292,293                                etp37c    37       200000   rs
-Ethernet294    294,295                                etp37d    37       200000   rs
-Ethernet296    296,297                                etp38a    38       200000   rs
-Ethernet298    298,299                                etp38b    38       200000   rs
-Ethernet300    300,301                                etp38c    38       200000   rs
-Ethernet302    302,303                                etp38d    38       200000   rs
-Ethernet304    304,305                                etp39a    39       200000   rs
-Ethernet306    306,307                                etp39b    39       200000   rs
-Ethernet308    308,309                                etp39c    39       200000   rs
-Ethernet310    310,311                                etp39d    39       200000   rs
-Ethernet312    312,313                                etp40a    40       200000   rs
-Ethernet314    314,315                                etp40b    40       200000   rs
-Ethernet316    316,317                                etp40c    40       200000   rs
-Ethernet318    318,319                                etp40d    40       200000   rs
-Ethernet320    320,321                                etp41a    41       200000   rs
-Ethernet322    322,323                                etp41b    41       200000   rs
-Ethernet324    324,325                                etp41c    41       200000   rs
-Ethernet326    326,327                                etp41d    41       200000   rs
-Ethernet328    328,329                                etp42a    42       200000   rs
-Ethernet330    330,331                                etp42b    42       200000   rs
-Ethernet332    332,333                                etp42c    42       200000   rs
-Ethernet334    334,335                                etp42d    42       200000   rs
-Ethernet336    336,337                                etp43a    43       200000   rs
-Ethernet338    338,339                                etp43b    43       200000   rs
-Ethernet340    340,341                                etp43c    43       200000   rs
-Ethernet342    342,343                                etp43d    43       200000   rs
-Ethernet344    344,345                                etp44a    44       200000   rs
-Ethernet346    346,347                                etp44b    44       200000   rs
-Ethernet348    348,349                                etp44c    44       200000   rs
-Ethernet350    350,351                                etp44d    44       200000   rs
-Ethernet352    352,353                                etp45a    45       200000   rs
-Ethernet354    354,355                                etp45b    45       200000   rs
-Ethernet356    356,357                                etp45c    45       200000   rs
-Ethernet358    358,359                                etp45d    45       200000   rs
-Ethernet360    360,361                                etp46a    46       200000   rs
-Ethernet362    362,363                                etp46b    46       200000   rs
-Ethernet364    364,365                                etp46c    46       200000   rs
-Ethernet366    366,367                                etp46d    46       200000   rs
-Ethernet368    368,369                                etp47a    47       200000   rs
-Ethernet370    370,371                                etp47b    47       200000   rs
-Ethernet372    372,373                                etp47c    47       200000   rs
-Ethernet374    374,375                                etp47d    47       200000   rs
-Ethernet376    376,377                                etp48a    48       200000   rs
-Ethernet378    378,379                                etp48b    48       200000   rs
-Ethernet380    380,381                                etp48c    48       200000   rs
-Ethernet382    382,383                                etp48d    48       200000   rs
-Ethernet384    384,385                                etp49a    49       200000   rs
-Ethernet386    386,387                                etp49b    49       200000   rs
-Ethernet388    388,389                                etp49c    49       200000   rs
-Ethernet390    390,391                                etp49d    49       200000   rs
-Ethernet392    392,393                                etp50a    50       200000   rs
-Ethernet394    394,395                                etp50b    50       200000   rs
-Ethernet396    396,397                                etp50c    50       200000   rs
-Ethernet398    398,399                                etp50d    50       200000   rs
-Ethernet400    400,401                                etp51a    51       200000   rs
-Ethernet402    402,403                                etp51b    51       200000   rs
-Ethernet404    404,405                                etp51c    51       200000   rs
-Ethernet406    406,407                                etp51d    51       200000   rs
-Ethernet408    408,409                                etp52a    52       200000   rs
-Ethernet410    410,411                                etp52b    52       200000   rs
-Ethernet412    412,413                                etp52c    52       200000   rs
-Ethernet414    414,415                                etp52d    52       200000   rs
-Ethernet416    416,417                                etp53a    53       200000   rs
-Ethernet418    418,419                                etp53b    53       200000   rs
-Ethernet420    420,421                                etp53c    53       200000   rs
-Ethernet422    422,423                                etp53d    53       200000   rs
-Ethernet424    424,425                                etp54a    54       200000   rs
-Ethernet426    426,427                                etp54b    54       200000   rs
-Ethernet428    428,429                                etp54c    54       200000   rs
-Ethernet430    430,431                                etp54d    54       200000   rs
-Ethernet432    432,433                                etp55a    55       200000   rs
-Ethernet434    434,435                                etp55b    55       200000   rs
-Ethernet436    436,437                                etp55c    55       200000   rs
-Ethernet438    438,439                                etp55d    55       200000   rs
-Ethernet440    440,441                                etp56a    56       200000   rs
-Ethernet442    442,443                                etp56b    56       200000   rs
-Ethernet444    444,445                                etp56c    56       200000   rs
-Ethernet446    446,447                                etp56d    56       200000   rs
-Ethernet448    448,449                                etp57a    57       200000   rs
-Ethernet450    450,451                                etp57b    57       200000   rs
-Ethernet452    452,453                                etp57c    57       200000   rs
-Ethernet454    454,455                                etp57d    57       200000   rs
-Ethernet456    456,457                                etp58a    58       200000   rs
-Ethernet458    458,459                                etp58b    58       200000   rs
-Ethernet460    460,461                                etp58c    58       200000   rs
-Ethernet462    462,463                                etp58d    58       200000   rs
-Ethernet464    464,465                                etp59a    59       200000   rs
-Ethernet466    466,467                                etp59b    59       200000   rs
-Ethernet468    468,469                                etp59c    59       200000   rs
-Ethernet470    470,471                                etp59d    59       200000   rs
-Ethernet472    472,473                                etp60a    60       200000   rs
-Ethernet474    474,475                                etp60b    60       200000   rs
-Ethernet476    476,477                                etp60c    60       200000   rs
-Ethernet478    478,479                                etp60d    60       200000   rs
-Ethernet480    480,481                                etp61a    61       200000   rs
-Ethernet482    482,483                                etp61b    61       200000   rs
-Ethernet484    484,485                                etp61c    61       200000   rs
-Ethernet486    486,487                                etp61d    61       200000   rs
-Ethernet488    488,489                                etp62a    62       200000   rs
-Ethernet490    490,491                                etp62b    62       200000   rs
-Ethernet492    492,493                                etp62c    62       200000   rs
-Ethernet494    494,495                                etp62d    62       200000   rs
-Ethernet496    496,497                                etp63a    63       200000   rs
-Ethernet498    498,499                                etp63b    63       200000   rs
-Ethernet500    500,501                                etp63c    63       200000   rs
-Ethernet502    502,503                                etp63d    63       200000   rs
-Ethernet504    504,505                                etp64a    64       200000   rs
-Ethernet506    506,507                                etp64b    64       200000   rs
-Ethernet508    508,509                                etp64c    64       200000   rs
-Ethernet510    510,511                                etp64d    64       200000   rs
-Ethernet512    512                                    etp65     65        25000   rs
+# name         lanes                                  alias     index    speed 
+Ethernet0      0,1                                    etp1a     1        200000
+Ethernet2      2,3                                    etp1b     1        200000
+Ethernet4      4,5                                    etp1c     1        200000
+Ethernet6      6,7                                    etp1d     1        200000
+Ethernet8      8,9                                    etp2a     2        200000
+Ethernet10     10,11                                  etp2b     2        200000
+Ethernet12     12,13                                  etp2c     2        200000
+Ethernet14     14,15                                  etp2d     2        200000
+Ethernet16     16,17                                  etp3a     3        200000
+Ethernet18     18,19                                  etp3b     3        200000
+Ethernet20     20,21                                  etp3c     3        200000
+Ethernet22     22,23                                  etp3d     3        200000
+Ethernet24     24,25                                  etp4a     4        200000
+Ethernet26     26,27                                  etp4b     4        200000
+Ethernet28     28,29                                  etp4c     4        200000
+Ethernet30     30,31                                  etp4d     4        200000
+Ethernet32     32,33                                  etp5a     5        200000
+Ethernet34     34,35                                  etp5b     5        200000
+Ethernet36     36,37                                  etp5c     5        200000
+Ethernet38     38,39                                  etp5d     5        200000
+Ethernet40     40,41                                  etp6a     6        200000
+Ethernet42     42,43                                  etp6b     6        200000
+Ethernet44     44,45                                  etp6c     6        200000
+Ethernet46     46,47                                  etp6d     6        200000
+Ethernet48     48,49                                  etp7a     7        200000
+Ethernet50     50,51                                  etp7b     7        200000
+Ethernet52     52,53                                  etp7c     7        200000
+Ethernet54     54,55                                  etp7d     7        200000
+Ethernet56     56,57                                  etp8a     8        200000
+Ethernet58     58,59                                  etp8b     8        200000
+Ethernet60     60,61                                  etp8c     8        200000
+Ethernet62     62,63                                  etp8d     8        200000
+Ethernet64     64,65                                  etp9a     9        200000
+Ethernet66     66,67                                  etp9b     9        200000
+Ethernet68     68,69                                  etp9c     9        200000
+Ethernet70     70,71                                  etp9d     9        200000
+Ethernet72     72,73                                  etp10a    10       200000
+Ethernet74     74,75                                  etp10b    10       200000
+Ethernet76     76,77                                  etp10c    10       200000
+Ethernet78     78,79                                  etp10d    10       200000
+Ethernet80     80,81                                  etp11a    11       200000
+Ethernet82     82,83                                  etp11b    11       200000
+Ethernet84     84,85                                  etp11c    11       200000
+Ethernet86     86,87                                  etp11d    11       200000
+Ethernet88     88,89                                  etp12a    12       200000
+Ethernet90     90,91                                  etp12b    12       200000
+Ethernet92     92,93                                  etp12c    12       200000
+Ethernet94     94,95                                  etp12d    12       200000
+Ethernet96     96,97                                  etp13a    13       200000
+Ethernet98     98,99                                  etp13b    13       200000
+Ethernet100    100,101                                etp13c    13       200000
+Ethernet102    102,103                                etp13d    13       200000
+Ethernet104    104,105                                etp14a    14       200000
+Ethernet106    106,107                                etp14b    14       200000
+Ethernet108    108,109                                etp14c    14       200000
+Ethernet110    110,111                                etp14d    14       200000
+Ethernet112    112,113                                etp15a    15       200000
+Ethernet114    114,115                                etp15b    15       200000
+Ethernet116    116,117                                etp15c    15       200000
+Ethernet118    118,119                                etp15d    15       200000
+Ethernet120    120,121                                etp16a    16       200000
+Ethernet122    122,123                                etp16b    16       200000
+Ethernet124    124,125                                etp16c    16       200000
+Ethernet126    126,127                                etp16d    16       200000
+Ethernet128    128,129                                etp17a    17       200000
+Ethernet130    130,131                                etp17b    17       200000
+Ethernet132    132,133                                etp17c    17       200000
+Ethernet134    134,135                                etp17d    17       200000
+Ethernet136    136,137                                etp18a    18       200000
+Ethernet138    138,139                                etp18b    18       200000
+Ethernet140    140,141                                etp18c    18       200000
+Ethernet142    142,143                                etp18d    18       200000
+Ethernet144    144,145                                etp19a    19       200000
+Ethernet146    146,147                                etp19b    19       200000
+Ethernet148    148,149                                etp19c    19       200000
+Ethernet150    150,151                                etp19d    19       200000
+Ethernet152    152,153                                etp20a    20       200000
+Ethernet154    154,155                                etp20b    20       200000
+Ethernet156    156,157                                etp20c    20       200000
+Ethernet158    158,159                                etp20d    20       200000
+Ethernet160    160,161                                etp21a    21       200000
+Ethernet162    162,163                                etp21b    21       200000
+Ethernet164    164,165                                etp21c    21       200000
+Ethernet166    166,167                                etp21d    21       200000
+Ethernet168    168,169                                etp22a    22       200000
+Ethernet170    170,171                                etp22b    22       200000
+Ethernet172    172,173                                etp22c    22       200000
+Ethernet174    174,175                                etp22d    22       200000
+Ethernet176    176,177                                etp23a    23       200000
+Ethernet178    178,179                                etp23b    23       200000
+Ethernet180    180,181                                etp23c    23       200000
+Ethernet182    182,183                                etp23d    23       200000
+Ethernet184    184,185                                etp24a    24       200000
+Ethernet186    186,187                                etp24b    24       200000
+Ethernet188    188,189                                etp24c    24       200000
+Ethernet190    190,191                                etp24d    24       200000
+Ethernet192    192,193                                etp25a    25       200000
+Ethernet194    194,195                                etp25b    25       200000
+Ethernet196    196,197                                etp25c    25       200000
+Ethernet198    198,199                                etp25d    25       200000
+Ethernet200    200,201                                etp26a    26       200000
+Ethernet202    202,203                                etp26b    26       200000
+Ethernet204    204,205                                etp26c    26       200000
+Ethernet206    206,207                                etp26d    26       200000
+Ethernet208    208,209                                etp27a    27       200000
+Ethernet210    210,211                                etp27b    27       200000
+Ethernet212    212,213                                etp27c    27       200000
+Ethernet214    214,215                                etp27d    27       200000
+Ethernet216    216,217                                etp28a    28       200000
+Ethernet218    218,219                                etp28b    28       200000
+Ethernet220    220,221                                etp28c    28       200000
+Ethernet222    222,223                                etp28d    28       200000
+Ethernet224    224,225                                etp29a    29       200000
+Ethernet226    226,227                                etp29b    29       200000
+Ethernet228    228,229                                etp29c    29       200000
+Ethernet230    230,231                                etp29d    29       200000
+Ethernet232    232,233                                etp30a    30       200000
+Ethernet234    234,235                                etp30b    30       200000
+Ethernet236    236,237                                etp30c    30       200000
+Ethernet238    238,239                                etp30d    30       200000
+Ethernet240    240,241                                etp31a    31       200000
+Ethernet242    242,243                                etp31b    31       200000
+Ethernet244    244,245                                etp31c    31       200000
+Ethernet246    246,247                                etp31d    31       200000
+Ethernet248    248,249                                etp32a    32       200000
+Ethernet250    250,251                                etp32b    32       200000
+Ethernet252    252,253                                etp32c    32       200000
+Ethernet254    254,255                                etp32d    32       200000
+Ethernet256    256,257                                etp33a    33       200000
+Ethernet258    258,259                                etp33b    33       200000
+Ethernet260    260,261                                etp33c    33       200000
+Ethernet262    262,263                                etp33d    33       200000
+Ethernet264    264,265                                etp34a    34       200000
+Ethernet266    266,267                                etp34b    34       200000
+Ethernet268    268,269                                etp34c    34       200000
+Ethernet270    270,271                                etp34d    34       200000
+Ethernet272    272,273                                etp35a    35       200000
+Ethernet274    274,275                                etp35b    35       200000
+Ethernet276    276,277                                etp35c    35       200000
+Ethernet278    278,279                                etp35d    35       200000
+Ethernet280    280,281                                etp36a    36       200000
+Ethernet282    282,283                                etp36b    36       200000
+Ethernet284    284,285                                etp36c    36       200000
+Ethernet286    286,287                                etp36d    36       200000
+Ethernet288    288,289                                etp37a    37       200000
+Ethernet290    290,291                                etp37b    37       200000
+Ethernet292    292,293                                etp37c    37       200000
+Ethernet294    294,295                                etp37d    37       200000
+Ethernet296    296,297                                etp38a    38       200000
+Ethernet298    298,299                                etp38b    38       200000
+Ethernet300    300,301                                etp38c    38       200000
+Ethernet302    302,303                                etp38d    38       200000
+Ethernet304    304,305                                etp39a    39       200000
+Ethernet306    306,307                                etp39b    39       200000
+Ethernet308    308,309                                etp39c    39       200000
+Ethernet310    310,311                                etp39d    39       200000
+Ethernet312    312,313                                etp40a    40       200000
+Ethernet314    314,315                                etp40b    40       200000
+Ethernet316    316,317                                etp40c    40       200000
+Ethernet318    318,319                                etp40d    40       200000
+Ethernet320    320,321                                etp41a    41       200000
+Ethernet322    322,323                                etp41b    41       200000
+Ethernet324    324,325                                etp41c    41       200000
+Ethernet326    326,327                                etp41d    41       200000
+Ethernet328    328,329                                etp42a    42       200000
+Ethernet330    330,331                                etp42b    42       200000
+Ethernet332    332,333                                etp42c    42       200000
+Ethernet334    334,335                                etp42d    42       200000
+Ethernet336    336,337                                etp43a    43       200000
+Ethernet338    338,339                                etp43b    43       200000
+Ethernet340    340,341                                etp43c    43       200000
+Ethernet342    342,343                                etp43d    43       200000
+Ethernet344    344,345                                etp44a    44       200000
+Ethernet346    346,347                                etp44b    44       200000
+Ethernet348    348,349                                etp44c    44       200000
+Ethernet350    350,351                                etp44d    44       200000
+Ethernet352    352,353                                etp45a    45       200000
+Ethernet354    354,355                                etp45b    45       200000
+Ethernet356    356,357                                etp45c    45       200000
+Ethernet358    358,359                                etp45d    45       200000
+Ethernet360    360,361                                etp46a    46       200000
+Ethernet362    362,363                                etp46b    46       200000
+Ethernet364    364,365                                etp46c    46       200000
+Ethernet366    366,367                                etp46d    46       200000
+Ethernet368    368,369                                etp47a    47       200000
+Ethernet370    370,371                                etp47b    47       200000
+Ethernet372    372,373                                etp47c    47       200000
+Ethernet374    374,375                                etp47d    47       200000
+Ethernet376    376,377                                etp48a    48       200000
+Ethernet378    378,379                                etp48b    48       200000
+Ethernet380    380,381                                etp48c    48       200000
+Ethernet382    382,383                                etp48d    48       200000
+Ethernet384    384,385                                etp49a    49       200000
+Ethernet386    386,387                                etp49b    49       200000
+Ethernet388    388,389                                etp49c    49       200000
+Ethernet390    390,391                                etp49d    49       200000
+Ethernet392    392,393                                etp50a    50       200000
+Ethernet394    394,395                                etp50b    50       200000
+Ethernet396    396,397                                etp50c    50       200000
+Ethernet398    398,399                                etp50d    50       200000
+Ethernet400    400,401                                etp51a    51       200000
+Ethernet402    402,403                                etp51b    51       200000
+Ethernet404    404,405                                etp51c    51       200000
+Ethernet406    406,407                                etp51d    51       200000
+Ethernet408    408,409                                etp52a    52       200000
+Ethernet410    410,411                                etp52b    52       200000
+Ethernet412    412,413                                etp52c    52       200000
+Ethernet414    414,415                                etp52d    52       200000
+Ethernet416    416,417                                etp53a    53       200000
+Ethernet418    418,419                                etp53b    53       200000
+Ethernet420    420,421                                etp53c    53       200000
+Ethernet422    422,423                                etp53d    53       200000
+Ethernet424    424,425                                etp54a    54       200000
+Ethernet426    426,427                                etp54b    54       200000
+Ethernet428    428,429                                etp54c    54       200000
+Ethernet430    430,431                                etp54d    54       200000
+Ethernet432    432,433                                etp55a    55       200000
+Ethernet434    434,435                                etp55b    55       200000
+Ethernet436    436,437                                etp55c    55       200000
+Ethernet438    438,439                                etp55d    55       200000
+Ethernet440    440,441                                etp56a    56       200000
+Ethernet442    442,443                                etp56b    56       200000
+Ethernet444    444,445                                etp56c    56       200000
+Ethernet446    446,447                                etp56d    56       200000
+Ethernet448    448,449                                etp57a    57       200000
+Ethernet450    450,451                                etp57b    57       200000
+Ethernet452    452,453                                etp57c    57       200000
+Ethernet454    454,455                                etp57d    57       200000
+Ethernet456    456,457                                etp58a    58       200000
+Ethernet458    458,459                                etp58b    58       200000
+Ethernet460    460,461                                etp58c    58       200000
+Ethernet462    462,463                                etp58d    58       200000
+Ethernet464    464,465                                etp59a    59       200000
+Ethernet466    466,467                                etp59b    59       200000
+Ethernet468    468,469                                etp59c    59       200000
+Ethernet470    470,471                                etp59d    59       200000
+Ethernet472    472,473                                etp60a    60       200000
+Ethernet474    474,475                                etp60b    60       200000
+Ethernet476    476,477                                etp60c    60       200000
+Ethernet478    478,479                                etp60d    60       200000
+Ethernet480    480,481                                etp61a    61       200000
+Ethernet482    482,483                                etp61b    61       200000
+Ethernet484    484,485                                etp61c    61       200000
+Ethernet486    486,487                                etp61d    61       200000
+Ethernet488    488,489                                etp62a    62       200000
+Ethernet490    490,491                                etp62b    62       200000
+Ethernet492    492,493                                etp62c    62       200000
+Ethernet494    494,495                                etp62d    62       200000
+Ethernet496    496,497                                etp63a    63       200000
+Ethernet498    498,499                                etp63b    63       200000
+Ethernet500    500,501                                etp63c    63       200000
+Ethernet502    502,503                                etp63d    63       200000
+Ethernet504    504,505                                etp64a    64       200000
+Ethernet506    506,507                                etp64b    64       200000
+Ethernet508    508,509                                etp64c    64       200000
+Ethernet510    510,511                                etp64d    64       200000
+Ethernet512    512                                    etp65     65        25000

--- a/device/mellanox/x86_64-nvidia_sn5600-r0/Mellanox-SN5600-V256/port_config.ini
+++ b/device/mellanox/x86_64-nvidia_sn5600-r0/Mellanox-SN5600-V256/port_config.ini
@@ -1,5 +1,6 @@
 ##
-## Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES.
+## SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
+## Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 ## Apache-2.0
 ##
 ## Licensed under the Apache License, Version 2.0 (the "License");


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Removed FEC mode from port_config.ini for SN5600 SKUs. FEC mode needs to come as part of user configuration as it depends on peer end capabilities as well.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
Modified port_config.ini

#### How to verify it
Loading the SKU and testing default configuration

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

