### PR TITLE
[BGP]Disable graceful restart to support scale scenario

### DIFF
--- a/files/image_config/constants/constants.yml
+++ b/files/image_config/constants/constants.yml
@@ -16,7 +16,7 @@ constants:
     use_deployment_id: false
     use_neighbors_meta: false
     graceful_restart:
-      enabled: true
+      enabled: false
       restart_time: 240
     multipath_relax:
       enabled: true

--- a/src/sonic-config-engine/tests/sample_output/py2/bgpd_frr.conf
+++ b/src/sonic-config-engine/tests/sample_output/py2/bgpd_frr.conf
@@ -48,10 +48,6 @@ router bgp 65100
 !
   bgp bestpath as-path multipath-relax
 !
-  bgp graceful-restart restart-time 240
-  bgp graceful-restart
-  bgp graceful-restart preserve-fw-state
-  bgp graceful-restart select-defer-time 45
 !
   bgp router-id 10.1.0.32
 !

--- a/src/sonic-config-engine/tests/sample_output/py2/bgpd_frr_bmp.conf
+++ b/src/sonic-config-engine/tests/sample_output/py2/bgpd_frr_bmp.conf
@@ -48,10 +48,6 @@ router bgp 65100
 !
   bgp bestpath as-path multipath-relax
 !
-  bgp graceful-restart restart-time 240
-  bgp graceful-restart
-  bgp graceful-restart preserve-fw-state
-  bgp graceful-restart select-defer-time 45
 !
 !
   bmp mirror buffer-limit 4294967214

--- a/src/sonic-config-engine/tests/sample_output/py2/bgpd_frr_dualtor.conf
+++ b/src/sonic-config-engine/tests/sample_output/py2/bgpd_frr_dualtor.conf
@@ -49,10 +49,6 @@ router bgp 65100
 !
   bgp bestpath as-path multipath-relax
 !
-  bgp graceful-restart restart-time 240
-  bgp graceful-restart
-  bgp graceful-restart preserve-fw-state
-  bgp graceful-restart select-defer-time 45
 !
   bgp router-id 10.1.0.32
 !

--- a/src/sonic-config-engine/tests/sample_output/py2/bgpd_quagga.conf
+++ b/src/sonic-config-engine/tests/sample_output/py2/bgpd_quagga.conf
@@ -20,8 +20,6 @@ router bgp 65100
   bgp log-neighbor-changes
   bgp bestpath as-path multipath-relax
   no bgp default ipv4-unicast
-  bgp graceful-restart restart-time 240
-  bgp graceful-restart
   bgp router-id 10.1.0.32
   network 10.1.0.32/32
   address-family ipv6

--- a/src/sonic-config-engine/tests/sample_output/py2/frr.conf
+++ b/src/sonic-config-engine/tests/sample_output/py2/frr.conf
@@ -68,10 +68,6 @@ router bgp 65100
 !
   bgp bestpath as-path multipath-relax
 !
-  bgp graceful-restart restart-time 240
-  bgp graceful-restart
-  bgp graceful-restart preserve-fw-state
-  bgp graceful-restart select-defer-time 45
 !
   bgp router-id 10.1.0.32
 !

--- a/src/sonic-config-engine/tests/sample_output/py2/t2-chassis-fe-bgpd.conf
+++ b/src/sonic-config-engine/tests/sample_output/py2/t2-chassis-fe-bgpd.conf
@@ -26,8 +26,6 @@ router bgp 4000 vrf VnetFE
   bgp log-neighbor-changes
   bgp bestpath as-path multipath-relax
   no bgp default ipv4-unicast
-  bgp graceful-restart restart-time 240
-  bgp graceful-restart
   bgp router-id 4.0.0.0
   neighbor 192.168.0.1 remote-as 3000
   neighbor 192.168.0.1 description Leaf01

--- a/src/sonic-config-engine/tests/sample_output/py3/bgpd_frr.conf
+++ b/src/sonic-config-engine/tests/sample_output/py3/bgpd_frr.conf
@@ -48,10 +48,6 @@ router bgp 65100
 !
   bgp bestpath as-path multipath-relax
 !
-  bgp graceful-restart restart-time 240
-  bgp graceful-restart
-  bgp graceful-restart preserve-fw-state
-  bgp graceful-restart select-defer-time 45
 !
   bgp router-id 10.1.0.32
 !

--- a/src/sonic-config-engine/tests/sample_output/py3/bgpd_frr_bmp.conf
+++ b/src/sonic-config-engine/tests/sample_output/py3/bgpd_frr_bmp.conf
@@ -48,10 +48,6 @@ router bgp 65100
 !
   bgp bestpath as-path multipath-relax
 !
-  bgp graceful-restart restart-time 240
-  bgp graceful-restart
-  bgp graceful-restart preserve-fw-state
-  bgp graceful-restart select-defer-time 45
 !
 !
   bmp mirror buffer-limit 4294967214

--- a/src/sonic-config-engine/tests/sample_output/py3/bgpd_frr_dualtor.conf
+++ b/src/sonic-config-engine/tests/sample_output/py3/bgpd_frr_dualtor.conf
@@ -49,10 +49,6 @@ router bgp 65100
 !
   bgp bestpath as-path multipath-relax
 !
-  bgp graceful-restart restart-time 240
-  bgp graceful-restart
-  bgp graceful-restart preserve-fw-state
-  bgp graceful-restart select-defer-time 45
 !
   bgp router-id 10.1.0.32
 !

--- a/src/sonic-config-engine/tests/sample_output/py3/bgpd_quagga.conf
+++ b/src/sonic-config-engine/tests/sample_output/py3/bgpd_quagga.conf
@@ -20,8 +20,6 @@ router bgp 65100
   bgp log-neighbor-changes
   bgp bestpath as-path multipath-relax
   no bgp default ipv4-unicast
-  bgp graceful-restart restart-time 240
-  bgp graceful-restart
   bgp router-id 10.1.0.32
   network 10.1.0.32/32
   address-family ipv6

--- a/src/sonic-config-engine/tests/sample_output/py3/frr.conf
+++ b/src/sonic-config-engine/tests/sample_output/py3/frr.conf
@@ -68,10 +68,6 @@ router bgp 65100
 !
   bgp bestpath as-path multipath-relax
 !
-  bgp graceful-restart restart-time 240
-  bgp graceful-restart
-  bgp graceful-restart preserve-fw-state
-  bgp graceful-restart select-defer-time 45
 !
   bgp router-id 10.1.0.32
 !


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Disable graceful restart to support scale scenario

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
Update constants.yml to disable graceful restart feature.

#### How to verify it
Load the image and verify if graceful restart configurations are not populated.

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

