### PR TITLE
[FRR]Adding BGPD optimization during peer going down

### DIFF
--- a/src/sonic-frr/patch/0081-bgpd-Optimize-evaluate-paths-for-a-peer-going-down.patch
+++ b/src/sonic-frr/patch/0081-bgpd-Optimize-evaluate-paths-for-a-peer-going-down.patch
@@ -1,0 +1,57 @@
+From f63a4be085b28c5138b95d55681f2bfb38bdaf4f Mon Sep 17 00:00:00 2001
+From: Donald Sharp <sharpd@nvidia.com>
+Date: Fri, 24 Jan 2025 15:04:13 -0500
+Subject: [PATCH] bgpd: Optimize evaluate paths for a peer going down
+
+Currently when a directly connected peer is going down
+BGP gets a call back for nexthop tracking in addition
+the interface down events.  On the interface down
+event BGP goes through and sets up a per peer Q that
+holds all the bgp path info's associated with that peer
+and then it goes and processes this in the future.  In
+the meantime zebra is also at work and sends a nexthop
+removal event to BGP as well.  This triggers a complete
+walk of all path info's associated with the bnc( which
+happens to be all the path info's already scheduled
+for removal here shortly).  This evaluate paths
+is not an inexpensive operation in addition the work
+for handling this is already being done via the
+peer down queue.  Let's optimize the bnc handling
+of evaluate paths and check to see if the peer is
+still up to actually do the work here.
+
+Signed-off-by: Donald Sharp <sharpd@nvidia.com>
+
+diff --git a/bgpd/bgp_nht.c b/bgpd/bgp_nht.c
+index 3b6db31ea0..196cc00385 100644
+--- a/bgpd/bgp_nht.c
++++ b/bgpd/bgp_nht.c
+@@ -1258,6 +1258,25 @@ void evaluate_paths(struct bgp_nexthop_cache *bnc)
+ 	}
+ 
+ 	LIST_FOREACH (path, &(bnc->paths), nh_thread) {
++		/*
++		 * Currently when a peer goes down, bgp immediately
++		 * sees this via the interface events( if it is directly
++		 * connected).  And in this case it takes and puts on
++		 * a special peer queue all path info's associated with
++		 * but these items are not yet processed typically when
++		 * the nexthop is being handled here.  Thus we end
++		 * up in a situation where the process Queue for BGP
++		 * is being asked to look at the same path info multiple
++		 * times.  Let's just cut to the chase here and if
++		 * the bnc has a peer associated with it and the path info
++		 * being looked at uses that peer and the peer is no
++		 * longer established we know the path_info is being
++		 * handled elsewhere and we do not need to process
++		 * it here at all since the pathinfo is going away
++		 */
++		if (peer && path->peer == peer && !peer_established(peer->connection))
++			continue;
++
+ 		if (path->type == ZEBRA_ROUTE_BGP &&
+ 		    (path->sub_type == BGP_ROUTE_NORMAL ||
+ 		     path->sub_type == BGP_ROUTE_STATIC ||
+-- 
+2.43.2
+

--- a/src/sonic-frr/patch/series
+++ b/src/sonic-frr/patch/series
@@ -61,3 +61,4 @@
 0078-vtysh-de-conditionalize-and-reorder-install-node.patch
 0079-staticd-add-support-for-srv6.patch
 0080-SRv6-vpn-route-and-sidlist-install.patch
+0081-bgpd-Optimize-evaluate-paths-for-a-peer-going-down.patch


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Add BGPD optimization during peer going donw

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
Adding patch

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

