### PR TITLE
[FRR]Fixing route update on duplicate link up event in promiscuous mode

### DIFF
--- a/src/sonic-frr/patch/0082-Revert-bgpd-upon-if-event-evaluate-bnc-with-matching.patch
+++ b/src/sonic-frr/patch/0082-Revert-bgpd-upon-if-event-evaluate-bnc-with-matching.patch
@@ -1,0 +1,78 @@
+From 086c32eb5bf2ebfb4805f76219c1a3bc5dd9213e Mon Sep 17 00:00:00 2001
+From: dgsudharsan <sudharsand@nvidia.com>
+Date: Wed, 19 Feb 2025 17:24:39 +0000
+Subject: [PATCH] Revert "bgpd: upon if event, evaluate bnc with matching
+ nexthop"
+
+This reverts commit 58592be57783a3b24e7351af2a5afc61299768df.
+
+diff --git a/bgpd/bgp_nht.c b/bgpd/bgp_nht.c
+index 196cc00385..78eb1a9183 100644
+--- a/bgpd/bgp_nht.c
++++ b/bgpd/bgp_nht.c
+@@ -751,10 +751,6 @@ static void bgp_nht_ifp_table_handle(struct bgp *bgp,
+ 				     struct interface *ifp, bool up)
+ {
+ 	struct bgp_nexthop_cache *bnc;
+-	struct nexthop *nhop;
+-	uint16_t other_nh_count;
+-	bool nhop_ll_found = false;
+-	bool nhop_found = false;
+ 
+ 	if (ifp->ifindex == IFINDEX_INTERNAL) {
+ 		zlog_warn("%s: The interface %s ignored", __func__, ifp->name);
+@@ -762,42 +758,9 @@ static void bgp_nht_ifp_table_handle(struct bgp *bgp,
+ 	}
+ 
+ 	frr_each (bgp_nexthop_cache, table, bnc) {
+-		other_nh_count = 0;
+-		nhop_ll_found = bnc->ifindex_ipv6_ll == ifp->ifindex;
+-		for (nhop = bnc->nexthop; nhop; nhop = nhop->next) {
+-			if (nhop->ifindex == bnc->ifindex_ipv6_ll)
+-				continue;
+-
+-			if (nhop->ifindex != ifp->ifindex) {
+-				other_nh_count++;
+-				continue;
+-			}
+-			if (nhop->vrf_id != ifp->vrf->vrf_id) {
+-				other_nh_count++;
+-				continue;
+-			}
+-			nhop_found = true;
+-		}
+-
+-		if (!nhop_found && !nhop_ll_found)
+-			/* The event interface does not match the nexthop cache
+-			 * entry */
+-			continue;
+-
+-		if (!up && other_nh_count > 0)
+-			/* Down event ignored in case of multiple next-hop
+-			 * interfaces. The other might interfaces might be still
+-			 * up. The cases where all interfaces are down or a bnc
+-			 * is invalid are processed by a separate zebra rnh
+-			 * messages.
+-			 */
++		if (bnc->ifindex_ipv6_ll != ifp->ifindex)
+ 			continue;
+ 
+-		if (!nhop_ll_found) {
+-			evaluate_paths(bnc);
+-			continue;
+-		}
+-
+ 		bnc->last_update = monotime(NULL);
+ 		bnc->change_flags = 0;
+ 
+@@ -810,7 +773,6 @@ static void bgp_nht_ifp_table_handle(struct bgp *bgp,
+ 		if (up) {
+ 			SET_FLAG(bnc->flags, BGP_NEXTHOP_VALID);
+ 			SET_FLAG(bnc->change_flags, BGP_NEXTHOP_CHANGED);
+-			/* change nexthop number only for ll */
+ 			bnc->nexthop_num = 1;
+ 		} else {
+ 			UNSET_FLAG(bnc->flags, BGP_NEXTHOP_PEER_NOTIFIED);
+-- 
+2.43.2
+

--- a/src/sonic-frr/patch/series
+++ b/src/sonic-frr/patch/series
@@ -61,3 +61,4 @@
 0078-vtysh-de-conditionalize-and-reorder-install-node.patch
 0079-staticd-add-support-for-srv6.patch
 0080-SRv6-vpn-route-and-sidlist-install.patch
+0082-Revert-bgpd-upon-if-event-evaluate-bnc-with-matching.patch


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Fixing route update on duplicate link up event in promiscuous mode. When running tcpdump on interfaces which have BGP neighbors a duplicate link up event is received as the interface enters promiscuous mode. However these shouldn't trigger route updates. Due to the commit 58592be57783a3b24e7351af2a5afc61299768df route updates are published.

```
2025 Feb 19 18:00:14.893285 r-leopard-72 DEBUG bgp#zebra[36]: [V6YM8-PV4KB] MESSAGE: ZEBRA_INTERFACE_UP PortChannel101 vrf default(0)
2025 Feb 19 18:00:14.893492 r-leopard-72 INFO bgp#staticd[49]: [YGHNZ-57CJY] Interface enabled Removing. PortChannel101 SIDs that depend on the interface
2025 Feb 19 18:01:17.900554 r-leopard-72 DEBUG bgp#zebra[36]: [V6YM8-PV4KB] MESSAGE: ZEBRA_INTERFACE_UP PortChannel101 vrf default(0)
2025 Feb 19 18:01:17.900554 r-leopard-72 DEBUG bgp#zebra[36]: [V6YM8-PV4KB] MESSAGE: ZEBRA_INTERFACE_UP PortChannel102 vrf default(0)
2025 Feb 19 18:01:17.900819 r-leopard-72 INFO bgp#staticd[49]: [YGHNZ-57CJY] Interface enabled Removing. PortChannel101 SIDs that depend on the interface
2025 Feb 19 18:01:17.900819 r-leopard-72 INFO bgp#staticd[49]: [YGHNZ-57CJY] Interface enabled Removing. PortChannel102 SIDs that depend on the interface
2025 Feb 19 18:01:38.689072 r-leopard-72 DEBUG bgp#zebra[36]: [V6YM8-PV4KB] MESSAGE: ZEBRA_INTERFACE_UP Ethernet0 vrf default(0)
2025 Feb 19 18:01:38.689072 r-leopard-72 INFO bgp#staticd[49]: [YGHNZ-57CJY] Interface enabled Removing. Ethernet0 SIDs that depend on the interface





```

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
Reverted the patch that causes the issue

#### How to verify it
Running tcpdump on bgp neighbor and verifying if there are no route updates.

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

