### PR TITLE
[Mellanox]Extending the ipinip json check to cover new Nvidia platforms

### DIFF
--- a/dockers/docker-orchagent/ipinip.json.j2
+++ b/dockers/docker-orchagent/ipinip.json.j2
@@ -66,7 +66,7 @@
         "TUNNEL_DECAP_TABLE:IPINIP_SUBNET" : {
             "tunnel_type":"IPINIP",
             "dscp_mode":"uniform",
-{% if "mlnx" in DEVICE_METADATA.localhost.platform %}
+{% if ("mlnx" in DEVICE_METADATA.localhost.platform or "nvidia" in DEVICE_METADATA.localhost.platform) %}
             "ecn_mode":"standard",
 {% else %}
             "ecn_mode":"copy_from_outer",
@@ -89,7 +89,7 @@
         "TUNNEL_DECAP_TABLE:IPINIP_TUNNEL" : {
             "tunnel_type":"IPINIP",
             "dscp_mode":"uniform",
-{% if "mlnx" in DEVICE_METADATA.localhost.platform %}
+{% if ("mlnx" in DEVICE_METADATA.localhost.platform or "nvidia" in DEVICE_METADATA.localhost.platform) %}
             "ecn_mode":"standard",
 {% else %}
             "ecn_mode":"copy_from_outer",
@@ -119,7 +119,7 @@
         "TUNNEL_DECAP_TABLE:IPINIP_SUBNET_V6" : {
             "tunnel_type":"IPINIP",
             "dscp_mode":"uniform",
-{% if "mlnx" in DEVICE_METADATA.localhost.platform %}
+{% if ("mlnx" in DEVICE_METADATA.localhost.platform or "nvidia" in DEVICE_METADATA.localhost.platform) %}
             "ecn_mode":"standard",
 {% else %}
             "ecn_mode":"copy_from_outer",
@@ -142,7 +142,7 @@
         "TUNNEL_DECAP_TABLE:IPINIP_V6_TUNNEL" : {
             "tunnel_type":"IPINIP",
             "dscp_mode":"uniform",
-{% if "mlnx" in DEVICE_METADATA.localhost.platform %}
+{% if ("mlnx" in DEVICE_METADATA.localhost.platform or "nvidia" in DEVICE_METADATA.localhost.platform) %}
             "ecn_mode":"standard",
 {% else %}
             "ecn_mode":"copy_from_outer",


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
The existing check compares "mlnx" string to apply specific ecn mode.  However newer platforms contain "nvidia" in platform string. So extending this check to cover newer platforms as well.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
Extending the check in j2 files to include nvidia platforms

#### How to verify it
Running regression tests.

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

