### PR TITLE
Fixing route display issue with 512 nexthops

### DIFF
--- a/src/sonic-frr/dplane_fpm_sonic/dplane_fpm_sonic.c
+++ b/src/sonic-frr/dplane_fpm_sonic/dplane_fpm_sonic.c
@@ -2167,6 +2167,7 @@ static ssize_t netlink_sidlist_msg_encode(int cmd,
 	return NLMSG_ALIGN(req->n.nlmsg_len);
 }
 
+#define DPLANE_FPM_NL_BUF_SIZE 65536
 /**
  * Encode data plane operation context into netlink and enqueue it in the FPM
  * output buffer.
@@ -2177,7 +2178,7 @@ static ssize_t netlink_sidlist_msg_encode(int cmd,
  */
 static int fpm_nl_enqueue(struct fpm_nl_ctx *fnc, struct zebra_dplane_ctx *ctx)
 {
-	uint8_t nl_buf[NL_PKT_BUF_SIZE];
+	uint8_t nl_buf[DPLANE_FPM_NL_BUF_SIZE];
 	size_t nl_buf_len;
 	ssize_t rv;
 	uint64_t obytes, obytes_peak;
@@ -2835,7 +2836,7 @@ static void fpm_process_queue(struct event *t)
 		}
 
 		/* No space available yet. */
-		if (writeable_amount < NL_PKT_BUF_SIZE) {
+		if (writeable_amount < DPLANE_FPM_NL_BUF_SIZE) {
 			no_bufs = true;
 			break;
 		}
@@ -2962,8 +2963,8 @@ static int fpm_nl_start(struct zebra_dplane_provider *prov)
 	fnc = dplane_provider_get_data(prov);
 	fnc->fthread = frr_pthread_new(NULL, prov_name, prov_name);
 	assert(frr_pthread_run(fnc->fthread, NULL) == 0);
-	fnc->ibuf = stream_new(NL_PKT_BUF_SIZE);
-	fnc->obuf = stream_new(NL_PKT_BUF_SIZE * 128);
+	fnc->ibuf = stream_new(DPLANE_FPM_NL_BUF_SIZE);
+	fnc->obuf = stream_new(DPLANE_FPM_NL_BUF_SIZE * 128);
 	pthread_mutex_init(&fnc->obuf_mutex, NULL);
 	fnc->socket = -1;
 	fnc->disabled = true;

--- a/src/sonic-frr/patch/0057-zebra-Ensure-that-the-dplane-can-send-the-full-packe.patch
+++ b/src/sonic-frr/patch/0057-zebra-Ensure-that-the-dplane-can-send-the-full-packe.patch
@@ -1,0 +1,57 @@
+From 7adb2b37705ecfeefaa31c5d72b4ae89a38eda2d Mon Sep 17 00:00:00 2001
+From: Donald Sharp <sharpd@nvidia.com>
+Date: Fri, 30 May 2025 18:51:09 -0400
+Subject: [PATCH 1/3] zebra: Ensure that the dplane can send the full packet
+
+Currently the buffer size used for encoding of routes is
+8192 bytes.  This is not a great choice for when you are using
+512 way ECMP with v6 nexthops.  You quickly run out of space.
+Let's just make the size big enough to just work for the forseeable
+future.
+
+Signed-off-by: Donald Sharp <sharpd@nvidia.com>
+
+diff --git a/zebra/dplane_fpm_nl.c b/zebra/dplane_fpm_nl.c
+index 96cfaab839..e164001bb6 100644
+--- a/zebra/dplane_fpm_nl.c
++++ b/zebra/dplane_fpm_nl.c
+@@ -924,6 +924,7 @@ static void fpm_connect(struct event *t)
+ 				&fnc->t_lspreset);
+ }
+ 
++#define DPLANE_FPM_NL_BUF_SIZE 65536
+ /**
+  * Encode data plane operation context into netlink and enqueue it in the FPM
+  * output buffer.
+@@ -934,7 +935,7 @@ static void fpm_connect(struct event *t)
+  */
+ static int fpm_nl_enqueue(struct fpm_nl_ctx *fnc, struct zebra_dplane_ctx *ctx)
+ {
+-	uint8_t nl_buf[NL_PKT_BUF_SIZE];
++	uint8_t nl_buf[DPLANE_FPM_NL_BUF_SIZE];
+ 	size_t nl_buf_len;
+ 	ssize_t rv;
+ 	uint64_t obytes, obytes_peak;
+@@ -1523,7 +1524,7 @@ static void fpm_process_queue(struct event *t)
+ 		}
+ 
+ 		/* No space available yet. */
+-		if (writeable_amount < NL_PKT_BUF_SIZE) {
++		if (writeable_amount < DPLANE_FPM_NL_BUF_SIZE) {
+ 			no_bufs = true;
+ 			break;
+ 		}
+@@ -1650,8 +1651,8 @@ static int fpm_nl_start(struct zebra_dplane_provider *prov)
+ 	fnc = dplane_provider_get_data(prov);
+ 	fnc->fthread = frr_pthread_new(NULL, prov_name, prov_name);
+ 	assert(frr_pthread_run(fnc->fthread, NULL) == 0);
+-	fnc->ibuf = stream_new(NL_PKT_BUF_SIZE);
+-	fnc->obuf = stream_new(NL_PKT_BUF_SIZE * 128);
++	fnc->ibuf = stream_new(DPLANE_FPM_NL_BUF_SIZE);
++	fnc->obuf = stream_new(DPLANE_FPM_NL_BUF_SIZE * 128);
+ 	pthread_mutex_init(&fnc->obuf_mutex, NULL);
+ 	fnc->socket = -1;
+ 	fnc->disabled = true;
+-- 
+2.43.2
+

--- a/src/sonic-frr/patch/series
+++ b/src/sonic-frr/patch/series
@@ -32,3 +32,4 @@
 0032-show-ipv6-route-json-displays-seg6local-flavors.patch
 0033-staticd-Install-known-nexthops-upon-connection-with-zebra.patch
 0034-staticd-Fix-an-issue-where-SRv6-SIDs-may-not-be-allocated-on-heavily-loaded-systems.patch
+0057-zebra-Ensure-that-the-dplane-can-send-the-full-packe.patch


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
When a route with 512 nexthops is programmed, show ipv6 route shows the route as queued, even though the route gets programmed in the hardware.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
Modifying dplane_fpm_sonic and added patches.


#### How to verify it
Install routes with 512 nexthops and confirm if they are not queued.


<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202205
- [ ] 202211
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

