### PR TITLE
[BGP]Preventing duplicate route reinstall

### DIFF
--- a/src/sonic-frr/patch/0063-bgpd-Prevent-unnecessary-re-install-of-routes.patch
+++ b/src/sonic-frr/patch/0063-bgpd-Prevent-unnecessary-re-install-of-routes.patch
@@ -1,0 +1,46 @@
+From 82eab0fa6940b462ffed3a1d6f57e53209dd405c Mon Sep 17 00:00:00 2001
+From: Donald Sharp <sharpd@nvidia.com>
+Date: Sat, 18 Oct 2025 10:22:56 -0400
+Subject: [PATCH] bgpd: Prevent unnecessary re-install of routes
+
+There is this sequence of events that is happening:
+
+a) BGP registers for a nexthop resolution for address A
+b) <time passes and BGP comes fully up>
+c) Something else in the system requests for the same
+nexthop resolution tracking for A
+d) Zebra wakes up and decides to send a update to BGP
+about the nexthop, even when nothing has happened.
+e) BGP decides that the nexthop has not changed but goes
+ahead and reinstalls everything again anyways.
+
+Let's modify BGP to be a bit smarter here.  It already
+knows that the nexthop hasn't changed, there is no need
+to run bgp_process on each route that is using the BNC.
+Let's stop this from happening.
+
+This is only 1/2 the fix.  I want to protect BGP from zebra
+but I also want zebra to not send the update to BGP in this case.
+That change is going to come in a different set of commits because
+it's a bit larger of a problem and will need a bit more work.
+
+Signed-off-by: Donald Sharp <sharpd@nvidia.com>
+
+diff --git a/bgpd/bgp_nht.c b/bgpd/bgp_nht.c
+index 8482188d74..c5e53948a9 100644
+--- a/bgpd/bgp_nht.c
++++ b/bgpd/bgp_nht.c
+@@ -1436,7 +1436,9 @@ void evaluate_paths(struct bgp_nexthop_cache *bnc)
+ 		if (path_valid != bnc_is_valid_nexthop)
+ 			hook_call(bgp_nht_path_update, bgp_path, path, bnc_is_valid_nexthop);
+ 
+-		bgp_process(bgp_path, dest, path, afi, safi);
++		if (CHECK_FLAG(bnc->change_flags, BGP_NEXTHOP_METRIC_CHANGED) ||
++		    CHECK_FLAG(bnc->change_flags, BGP_NEXTHOP_CHANGED))
++			bgp_process(bgp_path, dest, path, afi, safi);
+ 	}
+ 
+ 	if (peer) {
+-- 
+2.50.1
+

--- a/src/sonic-frr/patch/series
+++ b/src/sonic-frr/patch/series
@@ -59,3 +59,4 @@
 0059-zebra-Ensure-that-the-dplane-can-send-the-full-packe.patch
 0060-bgpd-Convert-bmp-path_info-tracking-from-hash-to-rbt.patch
 0061-bgpd-Fix-JSON-wrapper-brace-consistency-in-neighbor.patch
+0063-bgpd-Prevent-unnecessary-re-install-of-routes.patch


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Avoid duplicate route updates when static route gets added

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
Ported fix from FRR community.

#### How to verify it
Add static route and verify if there are no route updates from bgp.

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202205
- [ ] 202211
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

